### PR TITLE
Add option to save HTTP response body for debugging

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1787,6 +1787,36 @@ pre {
   color: var(--color-text);
 }
 
+/* HTML Preview Toggle Button */
+.html-preview__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.html-preview__toggle:hover {
+  background: var(--color-border);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.html-preview__toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
 .card-maximized-overlay {
   position: fixed;
   top: 56px; /* Account for navbar height */

--- a/frontend/js/components/html-preview.js
+++ b/frontend/js/components/html-preview.js
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview HTML preview component with toggle between code view and rendered preview.
+ */
+
+import { icons } from "../icons.js";
+import { CodeViewer } from "./code-viewer.js";
+import { Card, CardContent, CardHeader } from "./card.js";
+import { t } from "../i18n/index.js";
+import { CommandPalette } from "./command-palette.js";
+
+/**
+ * Counter for generating unique component instance IDs.
+ * @type {number}
+ */
+let instanceCounter = 0;
+
+/**
+ * View modes for the HTML preview component.
+ * @enum {string}
+ */
+export const HtmlPreviewMode = {
+  CODE: "code",
+  PREVIEW: "preview",
+};
+
+/**
+ * HTML preview component that can toggle between code view and iframe preview.
+ * Uses Card components for consistent styling.
+ * @type {Object}
+ */
+export const HtmlPreview = {
+  /**
+   * Renders the HTML preview component.
+   * @param {Object} vnode - Mithril vnode
+   * @param {Object} vnode.attrs - Component attributes
+   * @param {string} vnode.attrs.html - HTML content to display
+   * @param {string} [vnode.attrs.title] - Card header title
+   * @param {string} [vnode.attrs.maxHeight='400px'] - Maximum height for the content area
+   * @param {string} [vnode.attrs.defaultMode='preview'] - Initial view mode ('code' or 'preview')
+   * @param {string} [vnode.attrs.style] - Additional inline styles for the card
+   * @returns {Object} Mithril vnode
+   */
+  oninit(vnode) {
+    const { defaultMode = HtmlPreviewMode.PREVIEW } = vnode.attrs;
+    vnode.state.mode = defaultMode;
+    vnode.state.instanceId = `html-preview-${++instanceCounter}`;
+    HtmlPreview.registerPaletteCommands(vnode);
+  },
+
+  onremove(vnode) {
+    CommandPalette.unregisterItems(vnode.state.instanceId);
+  },
+
+  /**
+   * Registers commands with the command palette.
+   * @param {Object} vnode - Mithril vnode
+   */
+  registerPaletteCommands(vnode) {
+    const { mode, instanceId } = vnode.state;
+    const isCodeMode = mode === HtmlPreviewMode.CODE;
+    const items = [];
+
+    if (isCodeMode) {
+      items.push({
+        type: "custom",
+        label: t("execution.switchToPreview"),
+        description: t("execution.switchToPreviewDesc"),
+        icon: "eye",
+        onSelect: () => {
+          vnode.state.mode = HtmlPreviewMode.PREVIEW;
+          HtmlPreview.registerPaletteCommands(vnode);
+          m.redraw();
+        },
+      });
+    } else {
+      items.push({
+        type: "custom",
+        label: t("execution.switchToCode"),
+        description: t("execution.switchToCodeDesc"),
+        icon: "code",
+        onSelect: () => {
+          vnode.state.mode = HtmlPreviewMode.CODE;
+          HtmlPreview.registerPaletteCommands(vnode);
+          m.redraw();
+        },
+      });
+    }
+
+    CommandPalette.registerItems(instanceId, items);
+  },
+
+  view(vnode) {
+    const {
+      html = "",
+      title,
+      maxHeight = "400px",
+      style = "",
+    } = vnode.attrs;
+
+    const { mode } = vnode.state;
+    const isCodeMode = mode === HtmlPreviewMode.CODE;
+
+    const toggleMode = () => {
+      vnode.state.mode = isCodeMode
+        ? HtmlPreviewMode.PREVIEW
+        : HtmlPreviewMode.CODE;
+      HtmlPreview.registerPaletteCommands(vnode);
+    };
+
+    // Toggle button for header actions
+    const toggleButton = m(
+      "button.html-preview__toggle",
+      {
+        onclick: toggleMode,
+        title: isCodeMode
+          ? t("execution.showPreview")
+          : t("execution.showCode"),
+      },
+      m.trust(isCodeMode ? icons.eye() : icons.code()),
+    );
+
+    return m(Card, { style }, [
+      m(CardHeader, {
+        title: title ||
+          (isCodeMode
+            ? t("execution.responseBody")
+            : t("execution.htmlPreview")),
+        actions: [toggleButton],
+      }),
+      m(CardContent, { noPadding: true }, [
+        isCodeMode
+          ? m(CodeViewer, {
+            code: html,
+            language: "html",
+            maxHeight,
+            noBorder: true,
+            padded: true,
+          })
+          : m("iframe.html-preview__iframe", {
+            srcdoc: html,
+            style:
+              `width: 100%; height: ${maxHeight}; border: none; background: white;`,
+            sandbox: "allow-same-origin",
+          }),
+      ]),
+    ]);
+  },
+};

--- a/frontend/js/i18n/locales/en.js
+++ b/frontend/js/i18n/locales/en.js
@@ -158,6 +158,9 @@ export default {
       everyWeek: "Every Sunday at midnight",
     },
     nextRun: "Next scheduled run:",
+    saveResponse: "Save Response",
+    saveResponseDescription:
+      "Store HTTP responses with executions for debugging.",
   },
 
   // Executions
@@ -303,12 +306,21 @@ export default {
     executionNotFound: "Execution not found",
     executionError: "Execution Error",
     inputEvent: "Input Event (JSON)",
+    httpResponse: "HTTP Response",
+    responseBody: "Response Body",
+    htmlPreview: "HTML Preview",
     aiRequests: "AI Requests",
     aiRequestsCount: "{{count}} API calls",
     emailRequests: "Email Requests",
     emailsSent: "{{count}} emails sent",
     executionLogs: "Execution Logs",
     logEntries: "{{count}} log entries",
+    showPreview: "Show Preview",
+    showCode: "Show Code",
+    switchToPreview: "Switch to HTML Preview",
+    switchToPreviewDesc: "Show rendered HTML in preview mode",
+    switchToCode: "Switch to Code View",
+    switchToCodeDesc: "Show raw HTML source code",
   },
 
   // Version diff

--- a/frontend/js/i18n/locales/pt-BR.js
+++ b/frontend/js/i18n/locales/pt-BR.js
@@ -160,6 +160,9 @@ export default {
       everyWeek: "Todo domingo à meia-noite",
     },
     nextRun: "Próxima execução agendada:",
+    saveResponse: "Salvar Resposta",
+    saveResponseDescription:
+      "Armazena respostas HTTP com as execuções para depuração.",
   },
 
   // Executions
@@ -305,12 +308,21 @@ export default {
     executionNotFound: "Execução não encontrada",
     executionError: "Erro de Execução",
     inputEvent: "Evento de Entrada (JSON)",
+    httpResponse: "Resposta HTTP",
+    responseBody: "Corpo da Resposta",
+    htmlPreview: "Visualização HTML",
     aiRequests: "Requisições de IA",
     aiRequestsCount: "{{count}} chamadas de API",
     emailRequests: "Requisições de Email",
     emailsSent: "{{count}} emails enviados",
     executionLogs: "Logs de Execução",
     logEntries: "{{count}} entradas de log",
+    showPreview: "Mostrar Visualização",
+    showCode: "Mostrar Código",
+    switchToPreview: "Alternar para Visualização HTML",
+    switchToPreviewDesc: "Mostrar HTML renderizado no modo de visualização",
+    switchToCode: "Alternar para Visualização de Código",
+    switchToCodeDesc: "Mostrar código fonte HTML",
   },
 
   // Version diff

--- a/frontend/js/types.js
+++ b/frontend/js/types.js
@@ -33,6 +33,7 @@
  * @property {Object.<string, string>} [env_vars] - Environment variables
  * @property {string} [cron_schedule] - Cron expression for scheduled execution
  * @property {string} [cron_status] - Cron status ('active' or 'paused')
+ * @property {boolean} save_response - Whether to save HTTP responses for debugging
  * @property {string} created_at - ISO timestamp
  * @property {string} updated_at - ISO timestamp
  */
@@ -59,6 +60,8 @@
  * @property {number} duration_ms - Execution duration in milliseconds
  * @property {number} [status_code] - HTTP status code returned
  * @property {string} trigger - Execution trigger ('http' or 'cron')
+ * @property {string} [event_json] - Input event data as JSON string
+ * @property {string} [response_json] - HTTP response data as JSON string (if save_response enabled)
  * @property {string} created_at - ISO timestamp
  */
 
@@ -181,6 +184,7 @@
  * @property {boolean} [disabled] - Enable/disable function
  * @property {string} [cron_schedule] - Cron expression for scheduled execution
  * @property {string} [cron_status] - Cron status ('active' or 'paused')
+ * @property {boolean} [save_response] - Enable/disable response saving for debugging
  */
 
 /**

--- a/frontend/js/views/function-settings.js
+++ b/frontend/js/views/function-settings.js
@@ -130,6 +130,12 @@ export const FunctionSettings = {
   nextRunInfo: null,
 
   /**
+   * Edited save response state (null if unchanged).
+   * @type {boolean|null}
+   */
+  editedSaveResponse: null,
+
+  /**
    * Initializes the view and loads the function.
    * @param {Object} vnode - Mithril vnode
    */
@@ -143,6 +149,7 @@ export const FunctionSettings = {
     FunctionSettings.editedCronSchedule = null;
     FunctionSettings.editedCronStatus = null;
     FunctionSettings.nextRunInfo = null;
+    FunctionSettings.editedSaveResponse = null;
     FunctionSettings.loadFunction(vnode.attrs.id);
   },
 
@@ -166,6 +173,7 @@ export const FunctionSettings = {
       FunctionSettings.editedRetentionDays = null;
       FunctionSettings.editedCronSchedule = null;
       FunctionSettings.editedCronStatus = null;
+      FunctionSettings.editedSaveResponse = null;
       FunctionSettings.envVars = Object.entries(
         FunctionSettings.func.env_vars || {},
       ).map(([key, value]) => ({
@@ -230,12 +238,13 @@ export const FunctionSettings = {
     return (
       FunctionSettings.editedName !== null ||
       FunctionSettings.editedDescription !== null ||
-      FunctionSettings.editedRetentionDays !== null
+      FunctionSettings.editedRetentionDays !== null ||
+      FunctionSettings.editedSaveResponse !== null
     );
   },
 
   /**
-   * Saves general settings (name, description, retention) to the API.
+   * Saves general settings (name, description, retention, save_response) to the API.
    * @returns {Promise<void>}
    */
   saveGeneralSettings: async () => {
@@ -251,6 +260,9 @@ export const FunctionSettings = {
       }
       if (FunctionSettings.editedRetentionDays !== null) {
         updates.retention_days = FunctionSettings.editedRetentionDays || 7;
+      }
+      if (FunctionSettings.editedSaveResponse !== null) {
+        updates.save_response = FunctionSettings.editedSaveResponse;
       }
 
       await API.functions.update(FunctionSettings.func.id, updates);
@@ -481,6 +493,24 @@ export const FunctionSettings = {
                   text: t("settings.retentionHelp"),
                 }),
               ]),
+              m(FormCheckbox, {
+                id: "save-response",
+                label: t("settings.saveResponse"),
+                description: t("settings.saveResponseDescription"),
+                checked: FunctionSettings.editedSaveResponse !== null
+                  ? FunctionSettings.editedSaveResponse
+                  : func.save_response,
+                onchange: () => {
+                  const newValue = FunctionSettings.editedSaveResponse !== null
+                    ? !FunctionSettings.editedSaveResponse
+                    : !func.save_response;
+                  if (newValue === func.save_response) {
+                    FunctionSettings.editedSaveResponse = null;
+                  } else {
+                    FunctionSettings.editedSaveResponse = newValue;
+                  }
+                },
+              }),
             ]),
             m(CardFooter, [
               m(

--- a/frontend/test/SpecRunner.html
+++ b/frontend/test/SpecRunner.html
@@ -148,6 +148,10 @@
       type="module"
       src="spec/components/language-selector.spec.js"
     ></script>
+    <script
+      type="module"
+      src="spec/components/html-preview.spec.js"
+    ></script>
   </head>
   <body></body>
 </html>

--- a/frontend/test/preview-html-preview.html
+++ b/frontend/test/preview-html-preview.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HtmlPreview Component Preview</title>
+    <!-- Styles -->
+    <link rel="stylesheet" href="/css/styles.css" />
+    <link
+      rel="stylesheet"
+      href="/vendor/highlight.js/styles/github-dark.min.css"
+    />
+    <style>
+      body {
+        padding: 2rem;
+        background: var(--color-background);
+      }
+      .preview-section {
+        margin-bottom: 2rem;
+      }
+      .preview-section h2 {
+        color: var(--color-text);
+        margin-bottom: 1rem;
+        font-size: 1.25rem;
+      }
+      .preview-section p {
+        color: var(--color-text-muted);
+        margin-bottom: 1rem;
+        font-size: 0.875rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script src="/vendor/mithril/mithril.min.js"></script>
+    <script src="/vendor/highlight.js/highlight.min.js"></script>
+    <script src="/vendor/highlight.js/languages/xml.min.js"></script>
+    <script src="/vendor/highlight.js/languages/json.min.js"></script>
+    <script type="module">
+      import {
+        HtmlPreview,
+        HtmlPreviewMode,
+      } from "/js/components/html-preview.js";
+
+      // Sample HTML content for previewing
+      const simpleHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Simple Page</title>
+</head>
+<body>
+  <h1>Hello World</h1>
+  <p>This is a simple HTML page.</p>
+</body>
+</html>`;
+
+      const styledHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      background: rgba(255,255,255,0.1);
+      border-radius: 12px;
+      padding: 24px;
+      backdrop-filter: blur(10px);
+    }
+    h1 { margin: 0 0 16px 0; }
+    p { margin: 0; opacity: 0.9; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Styled Card</h1>
+    <p>This demonstrates a more complex HTML page with CSS styling.</p>
+  </div>
+</body>
+</html>`;
+
+      const formHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    form {
+      max-width: 400px;
+      background: white;
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    label {
+      display: block;
+      margin-bottom: 8px;
+      font-weight: 500;
+    }
+    input {
+      width: 100%;
+      padding: 8px 12px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      margin-bottom: 16px;
+      box-sizing: border-box;
+    }
+    button {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <form>
+    <label>Email</label>
+    <input type="email" placeholder="you@example.com" />
+    <label>Password</label>
+    <input type="password" placeholder="Enter password" />
+    <button type="submit">Sign In</button>
+  </form>
+</body>
+</html>`;
+
+      const tableHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 20px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid #eee;
+    }
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+    tr:hover { background: #f5f5f5; }
+  </style>
+</head>
+<body>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Duration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>my-function</td>
+        <td>Success</td>
+        <td>125ms</td>
+      </tr>
+      <tr>
+        <td>api-handler</td>
+        <td>Error</td>
+        <td>2350ms</td>
+      </tr>
+      <tr>
+        <td>webhook-processor</td>
+        <td>Success</td>
+        <td>89ms</td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>`;
+
+      // Preview App Component
+      const PreviewApp = {
+        view() {
+          return m(".preview-container", [
+            m("h1", {
+              style: "color: var(--color-text); margin-bottom: 2rem;",
+            }, "HtmlPreview Component Preview"),
+
+            // Simple HTML
+            m(".preview-section", [
+              m("h2", "Simple HTML"),
+              m(
+                "p",
+                "Basic HTML page with minimal content. Click the icon in the header to toggle between preview and code view.",
+              ),
+              m(HtmlPreview, {
+                html: simpleHtml,
+                maxHeight: "300px",
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+
+            // Styled HTML
+            m(".preview-section", [
+              m("h2", "Styled HTML with CSS"),
+              m(
+                "p",
+                "HTML page with embedded CSS styling and gradients.",
+              ),
+              m(HtmlPreview, {
+                html: styledHtml,
+                maxHeight: "350px",
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+
+            // Form HTML
+            m(".preview-section", [
+              m("h2", "HTML Form"),
+              m("p", "HTML form with styled inputs and button."),
+              m(HtmlPreview, {
+                html: formHtml,
+                maxHeight: "400px",
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+
+            // Table HTML
+            m(".preview-section", [
+              m("h2", "HTML Table"),
+              m("p", "HTML table with hover effects."),
+              m(HtmlPreview, {
+                html: tableHtml,
+                maxHeight: "350px",
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+
+            // Default to Code Mode
+            m(".preview-section", [
+              m("h2", "Default to Code Mode"),
+              m(
+                "p",
+                "This preview starts in code mode by setting defaultMode='code'.",
+              ),
+              m(HtmlPreview, {
+                html: simpleHtml,
+                maxHeight: "300px",
+                defaultMode: HtmlPreviewMode.CODE,
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+
+            // Custom Title
+            m(".preview-section", [
+              m("h2", "Custom Title"),
+              m(
+                "p",
+                "Using a custom title instead of the default dynamic title.",
+              ),
+              m(HtmlPreview, {
+                html: styledHtml,
+                title: "Custom Response Preview",
+                maxHeight: "300px",
+                style: "margin-bottom: 1rem",
+              }),
+            ]),
+          ]);
+        },
+      };
+
+      // Mount the preview app
+      m.mount(document.getElementById("app"), PreviewApp);
+    </script>
+  </body>
+</html>

--- a/frontend/test/spec/components/html-preview.spec.js
+++ b/frontend/test/spec/components/html-preview.spec.js
@@ -1,0 +1,422 @@
+/**
+ * @fileoverview Tests for HtmlPreview component.
+ */
+
+import {
+  HtmlPreview,
+  HtmlPreviewMode,
+} from "../../../js/components/html-preview.js";
+import { Card, CardContent, CardHeader } from "../../../js/components/card.js";
+import { CodeViewer } from "../../../js/components/code-viewer.js";
+import { CommandPalette } from "../../../js/components/command-palette.js";
+
+describe("HtmlPreviewMode", () => {
+  it("exports CODE mode", () => {
+    expect(HtmlPreviewMode.CODE).toBe("code");
+  });
+
+  it("exports PREVIEW mode", () => {
+    expect(HtmlPreviewMode.PREVIEW).toBe("preview");
+  });
+});
+
+describe("HtmlPreview", () => {
+  function createVnode(attrs = {}) {
+    return {
+      attrs: { html: "<h1>Hello</h1>", ...attrs },
+      state: {},
+    };
+  }
+
+  describe("oninit()", () => {
+    it("initializes mode to preview by default", () => {
+      const vnode = createVnode();
+      HtmlPreview.oninit(vnode);
+
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.PREVIEW);
+    });
+
+    it("initializes mode to code when defaultMode is code", () => {
+      const vnode = createVnode({ defaultMode: HtmlPreviewMode.CODE });
+      HtmlPreview.oninit(vnode);
+
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.CODE);
+    });
+
+    it("initializes mode to preview when defaultMode is preview", () => {
+      const vnode = createVnode({ defaultMode: HtmlPreviewMode.PREVIEW });
+      HtmlPreview.oninit(vnode);
+
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.PREVIEW);
+    });
+  });
+
+  describe("view()", () => {
+    it("renders Card component", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      expect(result.tag).toBe(Card);
+    });
+
+    it("renders CardHeader with title", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      expect(header).toBeTruthy();
+      expect(header.attrs.title).toBeTruthy();
+    });
+
+    it("renders CardContent", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      expect(content).toBeTruthy();
+      expect(content.attrs.noPadding).toBe(true);
+    });
+
+    it("applies custom style to Card", () => {
+      const vnode = createVnode({ style: "margin-bottom: 1rem" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      expect(result.attrs.style).toBe("margin-bottom: 1rem");
+    });
+  });
+
+  describe("preview mode", () => {
+    it("renders iframe in preview mode", () => {
+      const vnode = createVnode({ html: "<p>Test</p>" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe).toBeTruthy();
+    });
+
+    it("sets iframe srcdoc to html content", () => {
+      const html = "<div>My HTML</div>";
+      const vnode = createVnode({ html });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe.attrs.srcdoc).toBe(html);
+    });
+
+    it("sets iframe sandbox attribute", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe.attrs.sandbox).toBe("allow-same-origin");
+    });
+
+    it("applies maxHeight to iframe style", () => {
+      const vnode = createVnode({ maxHeight: "500px" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe.attrs.style).toContain("500px");
+    });
+
+    it("uses default maxHeight of 400px", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe.attrs.style).toContain("400px");
+    });
+  });
+
+  describe("code mode", () => {
+    it("renders CodeViewer in code mode", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer).toBeTruthy();
+    });
+
+    it("passes html as code to CodeViewer", () => {
+      const html = "<section>Content</section>";
+      const vnode = createVnode({ html });
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.code).toBe(html);
+    });
+
+    it("sets language to html in CodeViewer", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.language).toBe("html");
+    });
+
+    it("passes maxHeight to CodeViewer", () => {
+      const vnode = createVnode({ maxHeight: "300px" });
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.maxHeight).toBe("300px");
+    });
+
+    it("sets noBorder to true on CodeViewer", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.noBorder).toBe(true);
+    });
+
+    it("sets padded to true on CodeViewer", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.padded).toBe(true);
+    });
+  });
+
+  describe("toggle button", () => {
+    it("renders toggle button in header actions", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      expect(header.attrs.actions).toBeTruthy();
+      expect(header.attrs.actions.length).toBeGreaterThan(0);
+    });
+
+    it("toggle button has html-preview__toggle class", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      const toggleBtn = header.attrs.actions.find(
+        (a) => a && a.tag === "button",
+      );
+      expect(toggleBtn).toBeTruthy();
+      expect(getVnodeClass(toggleBtn)).toContain("html-preview__toggle");
+    });
+
+    it("clicking toggle button switches from preview to code mode", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      const toggleBtn = header.attrs.actions.find(
+        (a) => a && a.tag === "button",
+      );
+
+      toggleBtn.attrs.onclick();
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.CODE);
+    });
+
+    it("clicking toggle button switches from code to preview mode", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      const toggleBtn = header.attrs.actions.find(
+        (a) => a && a.tag === "button",
+      );
+
+      toggleBtn.attrs.onclick();
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.PREVIEW);
+    });
+  });
+
+  describe("custom title", () => {
+    it("uses custom title when provided", () => {
+      const vnode = createVnode({ title: "Custom Title" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      expect(header.attrs.title).toBe("Custom Title");
+    });
+
+    it("uses custom title in both modes", () => {
+      const vnode = createVnode({ title: "My HTML" });
+
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      let result = HtmlPreview.view(vnode);
+      let header = result.children.find((c) => c && c.tag === CardHeader);
+      expect(header.attrs.title).toBe("My HTML");
+
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      result = HtmlPreview.view(vnode);
+      header = result.children.find((c) => c && c.tag === CardHeader);
+      expect(header.attrs.title).toBe("My HTML");
+    });
+  });
+
+  describe("empty html", () => {
+    it("handles empty html string", () => {
+      const vnode = createVnode({ html: "" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+
+      expect(() => HtmlPreview.view(vnode)).not.toThrow();
+    });
+
+    it("renders iframe with empty srcdoc when html is empty", () => {
+      const vnode = createVnode({ html: "" });
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const iframe = content.children.find((c) => c && c.tag === "iframe");
+      expect(iframe.attrs.srcdoc).toBe("");
+    });
+
+    it("renders CodeViewer with empty code when html is empty", () => {
+      const vnode = createVnode({ html: "" });
+      vnode.state.mode = HtmlPreviewMode.CODE;
+      const result = HtmlPreview.view(vnode);
+
+      const content = result.children.find((c) => c && c.tag === CardContent);
+      const codeViewer = content.children.find(
+        (c) => c && c.tag === CodeViewer,
+      );
+      expect(codeViewer.attrs.code).toBe("");
+    });
+  });
+
+  describe("command palette integration", () => {
+    let registerSpy;
+    let unregisterSpy;
+
+    beforeEach(() => {
+      registerSpy = spyOn(CommandPalette, "registerItems");
+      unregisterSpy = spyOn(CommandPalette, "unregisterItems");
+    });
+
+    it("generates unique instance ID on oninit", () => {
+      const vnode1 = createVnode();
+      const vnode2 = createVnode();
+      HtmlPreview.oninit(vnode1);
+      HtmlPreview.oninit(vnode2);
+
+      expect(vnode1.state.instanceId).toBeDefined();
+      expect(vnode2.state.instanceId).toBeDefined();
+      expect(vnode1.state.instanceId).not.toBe(vnode2.state.instanceId);
+    });
+
+    it("registers palette commands on oninit", () => {
+      const vnode = createVnode();
+      HtmlPreview.oninit(vnode);
+
+      expect(registerSpy).toHaveBeenCalled();
+      const [source, items] = registerSpy.calls.mostRecent().args;
+      expect(source).toBe(vnode.state.instanceId);
+      expect(items.length).toBe(1);
+    });
+
+    it("registers 'switch to code' command in preview mode", () => {
+      const vnode = createVnode({ defaultMode: HtmlPreviewMode.PREVIEW });
+      HtmlPreview.oninit(vnode);
+
+      const [, items] = registerSpy.calls.mostRecent().args;
+      expect(items[0].icon).toBe("code");
+      expect(items[0].type).toBe("custom");
+      expect(typeof items[0].onSelect).toBe("function");
+    });
+
+    it("registers 'switch to preview' command in code mode", () => {
+      const vnode = createVnode({ defaultMode: HtmlPreviewMode.CODE });
+      HtmlPreview.oninit(vnode);
+
+      const [, items] = registerSpy.calls.mostRecent().args;
+      expect(items[0].icon).toBe("eye");
+      expect(items[0].type).toBe("custom");
+      expect(typeof items[0].onSelect).toBe("function");
+    });
+
+    it("unregisters palette commands on onremove", () => {
+      const vnode = createVnode();
+      HtmlPreview.oninit(vnode);
+      HtmlPreview.onremove(vnode);
+
+      expect(unregisterSpy).toHaveBeenCalledWith(vnode.state.instanceId);
+    });
+
+    it("re-registers commands when mode is toggled via command palette", () => {
+      const vnode = createVnode({ defaultMode: HtmlPreviewMode.PREVIEW });
+      HtmlPreview.oninit(vnode);
+
+      // Get the onSelect callback
+      const [, items] = registerSpy.calls.mostRecent().args;
+      const onSelect = items[0].onSelect;
+
+      // Simulate command palette selection
+      registerSpy.calls.reset();
+      onSelect();
+
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.CODE);
+      expect(registerSpy).toHaveBeenCalled();
+    });
+
+    it("re-registers commands when mode is toggled via button", () => {
+      const vnode = createVnode();
+      vnode.state.mode = HtmlPreviewMode.PREVIEW;
+      vnode.state.instanceId = "test-instance";
+      const result = HtmlPreview.view(vnode);
+
+      // Find and click the toggle button
+      const header = result.children.find((c) => c && c.tag === CardHeader);
+      const toggleBtn = header.attrs.actions.find(
+        (a) => a && a.tag === "button",
+      );
+
+      registerSpy.calls.reset();
+      toggleBtn.attrs.onclick();
+
+      expect(vnode.state.mode).toBe(HtmlPreviewMode.CODE);
+      expect(registerSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/test/spec/components/request-builder.spec.js
+++ b/frontend/test/spec/components/request-builder.spec.js
@@ -103,13 +103,16 @@ describe("RequestBuilder", () => {
 });
 
 describe("generateCodeExamples", () => {
+  // Function signature: generateCodeExamples(url, method, path, query, headers, body)
+
   it("generates correct URL with query params", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "GET",
-      "key=value",
-      "",
-      "",
+      "", // path
+      "key=value", // query
+      "", // headers
+      "", // body
     );
 
     expect(examples.curl).toContain("http://api.test.com/fn?key=value");
@@ -122,9 +125,10 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "GET",
-      "",
-      "",
-      "",
+      "", // path
+      "", // query
+      "", // headers
+      "", // body
     );
 
     // Should not have the ? query separator
@@ -136,9 +140,10 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "POST",
-      "",
-      "",
-      '{"data": "test"}',
+      "", // path
+      "", // query
+      "", // headers
+      '{"data": "test"}', // body
     );
 
     expect(examples.curl).toContain("-d");
@@ -152,9 +157,10 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "GET",
-      "",
-      "",
-      '{"data": "test"}',
+      "", // path
+      "", // query
+      "", // headers
+      '{"data": "test"}', // body
     );
 
     // GET should not include body even if provided
@@ -166,9 +172,10 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "GET",
-      "",
-      '{"Authorization": "Bearer token123"}',
-      "",
+      "", // path
+      "", // query
+      '{"Authorization": "Bearer token123"}', // headers
+      "", // body
     );
 
     expect(examples.curl).toContain("Authorization: Bearer token123");
@@ -184,9 +191,10 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "GET",
-      "",
-      "invalid json {{{",
-      "",
+      "", // path
+      "", // query
+      "invalid json {{{", // headers
+      "", // body
     );
 
     expect(examples.curl).toContain("http://api.test.com/fn");
@@ -197,13 +205,46 @@ describe("generateCodeExamples", () => {
     const examples = generateCodeExamples(
       "http://api.test.com/fn",
       "DELETE",
-      "",
-      "",
-      "",
+      "", // path
+      "", // query
+      "", // headers
+      "", // body
     );
 
     expect(examples.curl).toContain("curl -X DELETE");
     expect(examples.python).toContain("requests.delete");
     expect(examples.go).toContain('"DELETE"');
+  });
+
+  it("includes path in URL", () => {
+    const examples = generateCodeExamples(
+      "http://api.test.com/fn",
+      "GET",
+      "/users/123", // path
+      "", // query
+      "", // headers
+      "", // body
+    );
+
+    expect(examples.curl).toContain("http://api.test.com/fn/users/123");
+    expect(examples.javascript).toContain("http://api.test.com/fn/users/123");
+    expect(examples.python).toContain("http://api.test.com/fn/users/123");
+    expect(examples.go).toContain("http://api.test.com/fn/users/123");
+  });
+
+  it("combines path and query in URL", () => {
+    const examples = generateCodeExamples(
+      "http://api.test.com/fn",
+      "GET",
+      "/items", // path
+      "limit=10", // query
+      "", // headers
+      "", // body
+    );
+
+    expect(examples.curl).toContain("http://api.test.com/fn/items?limit=10");
+    expect(examples.javascript).toContain(
+      "http://api.test.com/fn/items?limit=10",
+    );
   });
 });

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -1265,6 +1265,11 @@ components:
             - active
             - paused
           example: "paused"
+        save_response:
+          type: boolean
+          description: Whether to save HTTP responses with executions for debugging
+          example: false
+          default: false
         created_at:
           type: integer
           format: int64
@@ -1374,6 +1379,11 @@ components:
             - cron
           example: "http"
           default: "http"
+        response_json:
+          type: string
+          nullable: true
+          description: JSON-encoded HTTP response (only present if save_response is enabled on the function). Contains statusCode, headers, body, and isBase64Encoded. Body is truncated to 1MB if larger.
+          example: '{"statusCode":200,"headers":{"Content-Type":"application/json"},"body":"{\"success\":true}","isBase64Encoded":false}'
         created_at:
           type: integer
           format: int64
@@ -1541,6 +1551,11 @@ components:
             - active
             - paused
           example: "active"
+        save_response:
+          type: boolean
+          nullable: true
+          description: Whether to save HTTP responses with executions for debugging
+          example: true
 
     UpdateEnvVarsRequest:
       type: object

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -72,7 +72,7 @@ func ValidateUpdateFunctionRequest(req *store.UpdateFunctionRequest) error {
 	}
 
 	// At least one field must be provided
-	if req.Name == nil && req.Description == nil && req.Code == nil && req.Disabled == nil && req.RetentionDays == nil && req.CronSchedule == nil && req.CronStatus == nil {
+	if req.Name == nil && req.Description == nil && req.Code == nil && req.Disabled == nil && req.RetentionDays == nil && req.CronSchedule == nil && req.CronStatus == nil && req.SaveResponse == nil {
 		return &ValidationError{Field: "request", Message: "at least one field must be provided for update"}
 	}
 
@@ -281,10 +281,4 @@ func validateCronStatus(status string) error {
 		Field:   "cron_status",
 		Message: fmt.Sprintf("cron_status must be one of: %v", AllowedCronStatuses),
 	}
-}
-
-// ValidateCronSchedule is a public function to validate cron expressions
-// Used by the scheduler and handlers
-func ValidateCronSchedule(schedule string) error {
-	return validateCronSchedule(schedule)
 }

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -613,6 +613,51 @@ func TestValidateUpdateFunctionRequest_WithCronSchedule(t *testing.T) {
 	}
 }
 
+func TestValidateUpdateFunctionRequest_WithSaveResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *store.UpdateFunctionRequest
+		wantErr bool
+	}{
+		{
+			name: "valid save_response true",
+			req: &store.UpdateFunctionRequest{
+				SaveResponse: boolPtr(true),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid save_response false",
+			req: &store.UpdateFunctionRequest{
+				SaveResponse: boolPtr(false),
+			},
+			wantErr: false,
+		},
+		{
+			name: "combined update with save_response",
+			req: &store.UpdateFunctionRequest{
+				Name:         strPtr("new-name"),
+				SaveResponse: boolPtr(true),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateUpdateFunctionRequest(tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateFunctionRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Helper function for creating bool pointers
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func TestValidateUpdateFunctionRequest_WithCronStatus(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/migrate/migrations/000009_add_save_response.down.sql
+++ b/internal/migrate/migrations/000009_add_save_response.down.sql
@@ -1,0 +1,5 @@
+-- Remove save_response setting from functions and response_json from executions
+-- Note: SQLite does not support DROP COLUMN in older versions
+-- This migration may require recreating the tables in older SQLite versions
+ALTER TABLE functions DROP COLUMN save_response;
+ALTER TABLE executions DROP COLUMN response_json;

--- a/internal/migrate/migrations/000009_add_save_response.up.sql
+++ b/internal/migrate/migrations/000009_add_save_response.up.sql
@@ -1,0 +1,3 @@
+-- Add save_response setting to functions and response_json to executions
+ALTER TABLE functions ADD COLUMN save_response BOOLEAN DEFAULT 0;
+ALTER TABLE executions ADD COLUMN response_json TEXT;

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -67,7 +67,7 @@ func (db *MemoryDB) ListFunctions(_ context.Context, params PaginationParams) ([
 			Function: fn,
 		}
 
-		// Find active version
+		// Find an active version
 		if versions, ok := db.versions[fn.ID]; ok {
 			for _, v := range versions {
 				if v.IsActive {
@@ -122,6 +122,9 @@ func (db *MemoryDB) UpdateFunction(_ context.Context, id string, updates UpdateF
 	}
 	if updates.CronStatus != nil {
 		fn.CronStatus = updates.CronStatus
+	}
+	if updates.SaveResponse != nil {
+		fn.SaveResponse = *updates.SaveResponse
 	}
 
 	fn.UpdatedAt = time.Now().Unix()
@@ -306,7 +309,7 @@ func (db *MemoryDB) GetExecution(_ context.Context, executionID string) (Executi
 	return exec, nil
 }
 
-func (db *MemoryDB) UpdateExecution(_ context.Context, executionID string, status ExecutionStatus, durationMs *int64, errorMsg *string) error {
+func (db *MemoryDB) UpdateExecution(_ context.Context, executionID string, status ExecutionStatus, durationMs *int64, errorMsg *string, responseJSON *string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
@@ -318,6 +321,7 @@ func (db *MemoryDB) UpdateExecution(_ context.Context, executionID string, statu
 	exec.Status = status
 	exec.DurationMs = durationMs
 	exec.ErrorMessage = errorMsg
+	exec.ResponseJSON = responseJSON
 	db.executions[executionID] = exec
 
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -69,7 +69,7 @@ type DB interface {
 
 	// UpdateExecution updates an execution's status and results.
 	// Returns ErrExecutionNotFound if the execution does not exist.
-	UpdateExecution(ctx context.Context, executionID string, status ExecutionStatus, durationMs *int64, errorMsg *string) error
+	UpdateExecution(ctx context.Context, executionID string, status ExecutionStatus, durationMs *int64, errorMsg *string, responseJSON *string) error
 
 	// ListExecutions returns paginated executions for a function.
 	ListExecutions(ctx context.Context, functionID string, params PaginationParams) ([]Execution, int64, error)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -96,6 +96,7 @@ type Function struct {
 	RetentionDays *int              `json:"retention_days,omitempty"`
 	CronSchedule  *string           `json:"cron_schedule,omitempty"`
 	CronStatus    *string           `json:"cron_status,omitempty"`
+	SaveResponse  bool              `json:"save_response"`
 	CreatedAt     int64             `json:"created_at"`
 	UpdatedAt     int64             `json:"updated_at"`
 }
@@ -120,6 +121,7 @@ type Execution struct {
 	DurationMs        *int64           `json:"duration_ms,omitempty"`
 	ErrorMessage      *string          `json:"error_message,omitempty"`
 	EventJSON         *string          `json:"event_json,omitempty"`
+	ResponseJSON      *string          `json:"response_json,omitempty"`
 	Trigger           ExecutionTrigger `json:"trigger"`
 	CreatedAt         int64            `json:"created_at"`
 }
@@ -166,4 +168,5 @@ type UpdateFunctionRequest struct {
 	RetentionDays *int    `json:"retention_days,omitempty"`
 	CronSchedule  *string `json:"cron_schedule,omitempty"`
 	CronStatus    *string `json:"cron_status,omitempty"`
+	SaveResponse  *bool   `json:"save_response,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Added `save_response` option to functions to enable saving HTTP responses with executions
- Implemented `HtmlPreview` component with toggle between code view and rendered HTML preview