### PR TITLE
Add initial Responsive design changes

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -3489,4 +3489,17 @@ pre {
   .pagination {
     display: grid;
   }
+
+  .navbar__breadcrumb-separator,
+  .navbar__breadcrumb {
+    display: none;
+  }
+
+  .template-cards {
+    grid-template-columns: unset;
+  }
+
+  .create-function-actions {
+    display: grid;
+  }
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -39,10 +39,6 @@
   --text-xl: 1.25rem;
   --text-2xl: 1.5rem;
   --text-3xl: 1.875rem;
-
-  /* Breakpoints */
-  --tablet-width: 765px;
-
   /* W3C Accessibility*/
   --min-interactive-element-size: 44px;
 }
@@ -68,7 +64,7 @@ main {
   max-width: 80rem;
   margin: 0 auto;
   width: 100%;
-  padding: 1.5rem;
+  padding: 1rem;
 }
 
 ::selection {
@@ -167,7 +163,7 @@ main {
   z-index: 50;
   display: flex;
   align-items: center;
-  padding: 1rem 1.5rem;
+  padding: 1rem;
   justify-content: space-between;
 }
 
@@ -209,7 +205,7 @@ main {
 }
 
 .navbar__breadcrumb {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 0.5rem;
 }
@@ -225,6 +221,7 @@ main {
 }
 
 .navbar__breadcrumb-separator {
+  display: none;
   color: var(--color-border);
 }
 
@@ -245,10 +242,12 @@ main {
   font-size: var(--text-sm);
   cursor: pointer;
   min-height: var(--min-interactive-element-size);
-  min-width: 240px;
+  min-width: var(--min-interactive-element-size);
+  place-content: center;
 }
 
 .navbar__search span {
+  display: none;
   flex: 1;
   text-align: left;
 }
@@ -1199,7 +1198,7 @@ main {
 
 .pagination {
   padding: 0.75rem 1rem;
-  display: flex;
+  display: grid;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
@@ -1300,7 +1299,7 @@ main {
 
 .layout-with-sidebar {
   display: grid;
-  grid-template-columns: 1fr 320px;
+  grid-template-columns: 1fr;
   gap: 24px;
   align-items: start;
 }
@@ -1314,8 +1313,8 @@ main {
    ============================================ */
 
 .docs-sidebar {
-  position: sticky;
-  top: 80px;
+  position: static;
+  max-height: none;
   background: var(--color-surface-30);
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -1488,7 +1487,7 @@ main {
 }
 
 .create-function-actions {
-  display: flex;
+  display: grid;
   gap: 0.5rem;
   margin-top: 2rem;
 }
@@ -1499,7 +1498,7 @@ main {
 
 .template-cards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: unset;
   gap: 1rem;
 }
 
@@ -3159,9 +3158,9 @@ pre {
   grid-template-columns: 1fr;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 768px) {
   .ai-request-viewer__panels {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
   }
 }
 
@@ -3263,9 +3262,9 @@ pre {
   grid-template-columns: 1fr;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 768px) {
   .email-request-viewer__panels {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
   }
 }
 
@@ -3315,11 +3314,12 @@ pre {
 }
 
 .language-selector__label {
+  display: none;
   font-weight: 500;
 }
 
 .language-selector__chevron {
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   width: 0.75rem;
@@ -3449,57 +3449,58 @@ pre {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
-/* ============================================
-   RESPONSIVE
-   ============================================ */
-
-@media (max-width: 768px) {
+@media (min-width: 768px) {
   .layout-with-sidebar {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 320px;
   }
 
   .docs-sidebar {
-    position: static;
-    max-height: none;
+    position: sticky;
+    top: 80px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
   }
 
   .navbar {
-    padding: 1rem;
+    padding: 1rem 1.5rem;
   }
 
   .navbar__search {
-    min-width: var(--min-interactive-element-size);
-    place-content: center;
+    min-width: 240px;
+    place-content: unset;
   }
 
-  .navbar__search span,
+  .navbar__search span {
+    display: flex;
+  }
+
   .navbar__search .kbd {
-    display: none;
+    display: flex;
   }
 
   .language-selector__label,
   .language-selector__chevron {
-    display: none;
+    display: flex;
   }
 
   main {
-    padding: 1rem;
+    padding: 1.5rem;
   }
 
   .pagination {
-    display: grid;
+    display: flex;
   }
 
   .navbar__breadcrumb-separator,
   .navbar__breadcrumb {
-    display: none;
+    display: flex;
   }
 
   .template-cards {
-    grid-template-columns: unset;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .create-function-actions {
-    display: grid;
+    display: flex;
   }
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -153,7 +153,6 @@ main {
 /* ============================================
    NAVBAR
    ============================================ */
-
 .navbar {
   border-bottom: 1px solid var(--color-border);
   background-color: rgba(9, 9, 11, 0.8);
@@ -1498,7 +1497,6 @@ main {
 
 .template-cards {
   display: grid;
-  grid-template-columns: unset;
   gap: 1rem;
 }
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1093,7 +1093,7 @@ main {
    ============================================ */
 
 .kbd {
-  display: inline-flex;
+  display: none;
   align-items: center;
   justify-content: center;
   padding: 0.125rem 0.375rem;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -39,6 +39,12 @@
   --text-xl: 1.25rem;
   --text-2xl: 1.5rem;
   --text-3xl: 1.875rem;
+
+  /* Breakpoints */
+  --tablet-width: 765px;
+
+  /* W3C Accessibility*/
+  --min-interactive-element-size: 44px;
 }
 
 * {
@@ -99,6 +105,7 @@ main {
     opacity: 0;
     transform: translateY(4px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -109,6 +116,7 @@ main {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -119,6 +127,7 @@ main {
     transform: translateX(100%);
     opacity: 0;
   }
+
   to {
     transform: translateX(0);
     opacity: 1;
@@ -150,7 +159,6 @@ main {
    ============================================ */
 
 .navbar {
-  height: 56px;
   border-bottom: 1px solid var(--color-border);
   background-color: rgba(9, 9, 11, 0.8);
   backdrop-filter: blur(12px);
@@ -159,7 +167,7 @@ main {
   z-index: 50;
   display: flex;
   align-items: center;
-  padding: 0 1.5rem;
+  padding: 1rem 1.5rem;
   justify-content: space-between;
 }
 
@@ -176,6 +184,8 @@ main {
   text-decoration: none;
   color: var(--color-text);
   font-weight: 500;
+  min-width: max-content;
+  min-height: var(--min-interactive-element-size);
 }
 
 .navbar__brand:hover {
@@ -194,6 +204,7 @@ main {
 }
 
 .navbar__brand-name {
+  font-size: var(--text-lg);
   color: var(--color-subtle);
 }
 
@@ -225,15 +236,26 @@ main {
 .navbar__search {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
   border: 1px solid var(--color-border);
   background-color: var(--color-surface);
   color: var(--color-subtle);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   cursor: pointer;
-  transition: border-color 0.2s;
+  min-height: var(--min-interactive-element-size);
+  min-width: 240px;
+}
+
+.navbar__search span {
+  flex: 1;
+  text-align: left;
+}
+
+.navbar__search svg {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
 }
 
 .navbar__search:hover {
@@ -244,20 +266,19 @@ main {
   height: 24px;
   width: 1px;
   background-color: var(--color-border);
-  margin: 0 4px;
 }
 
 .navbar__action {
   background: none;
   border: none;
   color: var(--color-subtle);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
   transition: color 0.2s;
   text-decoration: none;
-  display: flex;
-  align-items: center;
+  min-width: var(--min-interactive-element-size);
+  min-height: var(--min-interactive-element-size);
   gap: 0.25rem;
 }
 
@@ -330,7 +351,7 @@ main {
 }
 
 .btn--destructive {
-  background-color: #dc2626;
+  background-color: var(--color-danger);
   color: white;
 }
 
@@ -1086,8 +1107,9 @@ main {
 }
 
 .kbd--sm {
+  gap: 0.125rem;
   padding: 0.0625rem 0.25rem;
-  font-size: var(--text-2xs);
+  font-size: var(--text-sm);
 }
 
 /* ============================================
@@ -1178,7 +1200,6 @@ main {
 .pagination {
   padding: 0.75rem 1rem;
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
@@ -1594,19 +1615,24 @@ pre {
 .lua-kw {
   color: #c678dd;
 }
+
 .lua-func {
   color: #61afef;
 }
+
 .lua-str {
   color: #98c379;
 }
+
 .lua-num {
   color: #d19a66;
 }
+
 .lua-comment {
   color: #5c6370;
   font-style: italic;
 }
+
 .lua-field {
   color: #e06c75;
 }
@@ -1819,7 +1845,8 @@ pre {
 
 .card-maximized-overlay {
   position: fixed;
-  top: 56px; /* Account for navbar height */
+  top: 56px;
+  /* Account for navbar height */
   left: 0;
   right: 0;
   bottom: 0;
@@ -1836,7 +1863,8 @@ pre {
   width: 100%;
   height: 100%;
   max-width: calc(100vw - 48px);
-  max-height: calc(100vh - 56px - 48px); /* Account for navbar */
+  max-height: calc(100vh - 56px - 48px);
+  /* Account for navbar */
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 12px;
@@ -1889,7 +1917,7 @@ pre {
   background: #0d1117;
 }
 
-.card-maximized__content > * {
+.card-maximized__content>* {
   flex: 1;
   min-height: 0;
 }
@@ -1898,7 +1926,7 @@ pre {
   height: 100% !important;
 }
 
-.card-maximized__content .code-editor-container > div {
+.card-maximized__content .code-editor-container>div {
   height: 100% !important;
 }
 
@@ -2713,7 +2741,7 @@ pre {
 }
 
 .code-viewer--no-border,
-.card .card__content > .code-viewer {
+.card .card__content>.code-viewer {
   border: none;
   border-radius: 0;
 }
@@ -2836,7 +2864,7 @@ pre {
   margin-bottom: 2rem;
 }
 
-.preview-section > h3 {
+.preview-section>h3 {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-text-muted);
@@ -2875,28 +2903,6 @@ pre {
   border-radius: 4px;
 }
 
-/* ============================================
-   RESPONSIVE
-   ============================================ */
-
-@media (max-width: 768px) {
-  .layout-with-sidebar {
-    grid-template-columns: 1fr;
-  }
-
-  .docs-sidebar {
-    position: static;
-    max-height: none;
-  }
-
-  .navbar {
-    padding: 0 1rem;
-  }
-
-  main {
-    padding: 1rem;
-  }
-}
 
 /* ============================================
    COMMAND PALETTE
@@ -3109,7 +3115,7 @@ pre {
   background: var(--color-background);
 }
 
-.ai-request-viewer__expanded-row > td {
+.ai-request-viewer__expanded-row>td {
   padding: 0;
   border-top: none;
 }
@@ -3210,7 +3216,7 @@ pre {
   background: var(--color-background);
 }
 
-.email-request-viewer__expanded-row > td {
+.email-request-viewer__expanded-row>td {
   padding: 0;
   border-top: none;
 }
@@ -3274,15 +3280,19 @@ pre {
 .language-selector__toggle {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
   background: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
+  padding: 0 0.5rem;
   color: var(--color-subtle);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   cursor: pointer;
   transition: all 0.2s;
+  border-radius: 8px;
+  min-height: var(--min-interactive-element-size);
+  min-width: var(--min-interactive-element-size);
 }
 
 .language-selector__toggle:hover {
@@ -3437,4 +3447,46 @@ pre {
   outline: none;
   border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+
+@media (max-width: 768px) {
+  .layout-with-sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-sidebar {
+    position: static;
+    max-height: none;
+  }
+
+  .navbar {
+    padding: 1rem;
+  }
+
+  .navbar__search {
+    min-width: var(--min-interactive-element-size);
+    place-content: center;
+  }
+
+  .navbar__search span,
+  .navbar__search .kbd {
+    display: none;
+  }
+
+  .language-selector__label,
+  .language-selector__chevron {
+    display: none;
+  }
+
+  main {
+    padding: 1rem;
+  }
+
+  .pagination {
+    display: grid;
+  }
 }

--- a/frontend/js/components/navbar.js
+++ b/frontend/js/components/navbar.js
@@ -183,7 +183,11 @@ export const NavbarSearch = {
         class: className,
         onclick,
       },
-      [m("span", placeholder), shortcut && m(Kbd, { small: true }, shortcut)],
+      [
+        m.trust(icons.magnifyingGlass()),
+        m("span", placeholder),
+        shortcut && m(Kbd, { small: true }, shortcut),
+      ],
     );
   },
 };
@@ -272,19 +276,18 @@ export const Header = {
     const { breadcrumb, onLogout, onSearch } = vnode.attrs;
 
     return m(Navbar, [
-      m(NavbarSection, [
-        m(NavbarBrand, { name: t("nav.dashboard"), href: "#!/" }),
-        breadcrumb &&
-        m(
-          "span.navbar__breadcrumb-separator",
-          { "aria-hidden": "true" },
-          "/",
-        ),
-        breadcrumb &&
-        m(NavbarBreadcrumb, {
-          items: [{ label: breadcrumb, active: true }],
-        }),
-      ]),
+      m(NavbarBrand, { name: t("nav.dashboard"), href: "#!/" }),
+      breadcrumb &&
+      m(
+        "span.navbar__breadcrumb-separator",
+        { "aria-hidden": "true" },
+        "/",
+      ),
+      breadcrumb &&
+      m(NavbarBreadcrumb, {
+        items: [{ label: breadcrumb, active: true }],
+      }),
+
       m(NavbarSection, [
         m(NavbarSearch, {
           placeholder: t("nav.search"),

--- a/frontend/js/icons.js
+++ b/frontend/js/icons.js
@@ -206,6 +206,10 @@ export const icons = {
   /** Route/map-pin icon - for routing */
   route: () =>
     `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16"><path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z"/></svg>`,
+
+  /** Bars/burger icon - for mobile menu */
+  bars3: () =>
+    `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32" stroke-width="1.5" stroke="currentColor" width="32" height="32"><path stroke-linecap="round" stroke-linejoin="round" d="M4 8h24M4 16h24M4 24h24" /></svg>`,
 };
 
 /**

--- a/frontend/js/views/function-create.js
+++ b/frontend/js/views/function-create.js
@@ -190,18 +190,18 @@ export const FunctionCreate = {
           m(
             Button,
             {
-              variant: ButtonVariant.GHOST,
-              href: "#!/functions",
-            },
-            t("common.cancel"),
-          ),
-          m(
-            Button,
-            {
               variant: ButtonVariant.PRIMARY,
               onclick: FunctionCreate.createFunction,
             },
             t("create.createButton"),
+          ),
+          m(
+            Button,
+            {
+              variant: ButtonVariant.GHOST,
+              href: "#!/functions",
+            },
+            t("common.cancel"),
           ),
         ]),
       ]),


### PR DESCRIPTION
## Description
This PR significantly improves the responsiveness and user interface of the Lunar Dashboard. It transitions the CSS architecture from a desktop-first approach to a mobile-first strategy, ensuring a faster and cleaner experience on smaller devices while maintaining a premium feel on desktop. 

### Mobile-First CSS Architecture
- Default-to-Mobile: Refactored  frontend/css/styles.css
 so that base styles represent the mobile view. Desktop-specific layouts are now applied via @media (min-width: 768px) overrides. Standardized the system to use a consistent 768px breakpoint, replacing various ad-hoc media queries and ensuring a predictable transition between viewports.
- Improved Performance: Reduced the browser overhead on mobile devices by eliminating the need to "undo" complex desktop declarations.

### Header design
- To be able to fit the current interactive components on the header, the breadcrums are hidden on mobile 
- Add an icon for the search bar to simplify the design on mobile
- Use icons only for search and language on the header

### Dashboard design
- Make the footer to take 2 rows on mobile to fit all the information 

|  <img width="393" height="682" alt="Screenshot 2026-02-24 at 20 10 14" src="https://github.com/user-attachments/assets/15184684-4f7b-48a7-8361-ec744ed2696a" /> | <img width="393" height="682" alt="Screenshot 2026-02-24 at 20 13 48" src="https://github.com/user-attachments/assets/a6616fd2-9d94-4cd3-b91f-d74a6d506a9a" /> | 



# Next steps
There is still changes to be done on the function page and subpages
