### PR TITLE
Add GoReleaser setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+version: 2
+
+builds:
+  - main: ./cmd
+    binary: lunar
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+
+dockers_v2:
+  - images:
+      - "dimiro1/lunar"
+    tags:
+      - "v{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: goreleaser.Dockerfile
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ dev:
 install-tools:
 	@echo "Installing development tools..."
 	@go install github.com/air-verse/air@latest
+	@go install github.com/goreleaser/goreleaser/v2@latest
 
 fmt-frontend:
 	@echo "Formatting frontend..."

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates tzdata
+
+WORKDIR /app
+
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/lunar .
+
+EXPOSE 3000
+
+ENV DATA_DIR=/data \
+    EXECUTION_TIMEOUT=300
+
+CMD ["./lunar"]


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` config to build binaries (linux/darwin, amd64/arm64) and multi-platform Docker images (`dimiro1/lunar`)
- Add `goreleaser.Dockerfile` for slim runtime images
- Add `.github/workflows/release.yml` triggered on `v*` tags
- Add `goreleaser` to Makefile `install-tools` target

> **Note:** I don't have much experience with GoReleaser, so the config might need adjustments. Feedback is welcome!

## Setup required

Add these GitHub secrets before the first release:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (with Read & Write permission)

## How to release

```
git tag v0.4.0
git push origin v0.4.0
```