### PR TITLE
Add device authorization flow for API token management

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/dimiro1/lunar/internal/token"
 )
 
 type Config struct {
@@ -48,11 +48,7 @@ func loadTimeout(getenv func(string) string) time.Duration {
 }
 
 func generateAPIKey() (string, error) {
-	randomBytes := make([]byte, 32)
-	if _, err := rand.Read(randomBytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(randomBytes), nil
+	return token.Generate()
 }
 
 func loadAPIKey(getenv func(string) string, dataDir string) (string, error) {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -3465,23 +3465,6 @@ pre {
   background: var(--color-surface);
 }
 
-/* ============================================
-   CENTERED PAGE (for pages with navbar)
-   ============================================ */
-
-.centered-page {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: calc(100vh - 56px);
-  padding: 1rem;
-}
-
-.centered-page__card {
-  width: 100%;
-  max-width: 400px;
-}
-
 /* KV Tab */
 .kv-tab-container {
   display: flex;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -3439,6 +3439,49 @@ pre {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
+/* ============================================
+   CODE DISPLAY
+   ============================================ */
+
+.code-display {
+  text-align: center;
+}
+
+.code-display__label {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.code-display__value {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  color: var(--color-text);
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+/* ============================================
+   CENTERED PAGE (for pages with navbar)
+   ============================================ */
+
+.centered-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 56px);
+  padding: 1rem;
+}
+
+.centered-page__card {
+  width: 100%;
+  max-width: 400px;
+}
+
 /* KV Tab */
 .kv-tab-container {
   display: flex;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -101,6 +101,26 @@ export const API = {
         method: "POST",
         url: "/api/auth/logout",
       }),
+
+    getDeviceApproveStatus: (code) =>
+      apiRequest({
+        method: "GET",
+        url: `/api/auth/device-approve?code=${code}`,
+      }),
+
+    approveDevice: (deviceCode, action) =>
+      apiRequest({
+        method: "POST",
+        url: "/api/auth/device-approve",
+        body: { device_code: deviceCode, action },
+      }),
+  },
+
+  tokens: {
+    list: () => apiRequest({ method: "GET", url: "/api/tokens" }),
+
+    revoke: (id) =>
+      apiRequest({ method: "POST", url: `/api/tokens/${id}/revoke` }),
   },
 
   /**

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -22,6 +22,8 @@ import { FunctionData } from "./views/function-data.js";
 import { ExecutionDetail } from "./views/execution-detail.js";
 import { VersionDiff } from "./views/version-diff.js";
 import { Preview } from "./views/preview.js";
+import { DeviceApprove } from "./views/device-approve.js";
+import { ConnectedClients } from "./views/connected-clients.js";
 import { API } from "./api.js";
 
 /**
@@ -155,5 +157,17 @@ m.route(document.getElementById("app"), "/functions", {
         { breadcrumb: "Key-Value Store", breadcrumbKey: "kvStore.title" },
         m(FunctionData, { ...vnode.attrs, key: vnode.attrs.id }),
       ),
+  },
+  "/device-approve/:code": {
+    render: (vnode) =>
+      m(
+        Layout,
+        { breadcrumbKey: "deviceApprove.title" },
+        m(DeviceApprove, { ...vnode.attrs, key: vnode.attrs.code }),
+      ),
+  },
+  "/clients": {
+    render: () =>
+      m(Layout, { breadcrumbKey: "clients.title" }, m(ConnectedClients)),
   },
 });

--- a/frontend/js/components/code-display.js
+++ b/frontend/js/components/code-display.js
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Code display component for prominent verification codes.
+ */
+
+/**
+ * CodeDisplay component - renders a large, styled code value.
+ * Designed for displaying verification codes, tokens, or similar short values.
+ * @type {Object}
+ * @example
+ * m(CodeDisplay, { value: "ABCD-1234" })
+ * m(CodeDisplay, { value: "ABCD-1234", label: "Verification Code" })
+ */
+export const CodeDisplay = {
+  view(vnode) {
+    const { value, label } = vnode.attrs;
+
+    return m(".code-display", [
+      label && m(".code-display__label", label),
+      m(".code-display__value", value),
+    ]);
+  },
+};

--- a/frontend/js/components/command-palette.js
+++ b/frontend/js/components/command-palette.js
@@ -171,6 +171,13 @@ export const CommandPalette = {
         path: paths.functionCreate(),
         icon: "plus",
       },
+      {
+        type: "nav",
+        label: t("clients.title"),
+        description: t("commandPalette.actions.viewClients"),
+        path: paths.clients(),
+        icon: "network",
+      },
     ];
 
     // Function items with actions for each function

--- a/frontend/js/components/navbar.js
+++ b/frontend/js/components/navbar.js
@@ -292,6 +292,16 @@ export const Header = {
           onclick: onSearch,
         }),
         m(NavbarDivider),
+        m(NavbarAction, {
+          label: t("nav.functions"),
+          href: "#!/functions",
+        }),
+        m(NavbarDivider),
+        m(NavbarAction, {
+          label: t("nav.clients"),
+          href: "#!/clients",
+        }),
+        m(NavbarDivider),
         m(LanguageSelector),
         m(NavbarDivider),
         m(NavbarAction, {

--- a/frontend/js/i18n/locales/en.js
+++ b/frontend/js/i18n/locales/en.js
@@ -32,6 +32,8 @@ export default {
     dashboard: "Dashboard",
     logout: "Logout",
     search: "Search",
+    functions: "Functions",
+    clients: "Clients",
   },
 
   // Login page
@@ -222,6 +224,7 @@ export default {
       viewExecutions: "View execution logs",
       configureFunction: "Configure function",
       testFunction: "Test function",
+      viewClients: "View connected clients",
       switchLanguage: "Switch language",
     },
     currentLanguage: "(current)",
@@ -577,5 +580,36 @@ export default {
         randomId: "Unique sortable ID",
       },
     },
+  },
+
+  // Connected clients
+  clients: {
+    title: "Connected Clients",
+    allClients: "All Clients",
+    totalCount: "{{count}} clients total",
+    noClients: "No connected clients.",
+    name: "Name",
+    created: "Created",
+    lastUsed: "Last Used",
+    status: "Status",
+    actions: "Actions",
+    revoke: "Revoke",
+    revokeConfirm: "Are you sure you want to revoke this token?",
+    active: "Active",
+    revoked: "Revoked",
+    neverUsed: "Never",
+  },
+
+  // Device authorization
+  deviceApprove: {
+    title: "Device Authorization",
+    description: "A CLI client is requesting access to your Lunar instance.",
+    userCode: "Verify this code matches your CLI:",
+    allow: "Allow",
+    deny: "Deny",
+    approved: "CLI client has been authorized. You can close this page.",
+    denied: "Access denied. The CLI will not be authorized.",
+    expired: "This authorization request has expired or is invalid.",
+    notFound: "Authorization request not found.",
   },
 };

--- a/frontend/js/i18n/locales/pt-BR.js
+++ b/frontend/js/i18n/locales/pt-BR.js
@@ -32,6 +32,8 @@ export default {
     dashboard: "Painel",
     logout: "Sair",
     search: "Buscar",
+    functions: "Funções",
+    clients: "Clientes",
   },
 
   // Login page
@@ -224,6 +226,7 @@ export default {
       viewExecutions: "Ver logs de execução",
       configureFunction: "Configurar função",
       testFunction: "Testar função",
+      viewClients: "Ver clientes conectados",
       switchLanguage: "Mudar idioma",
     },
     currentLanguage: "(atual)",
@@ -580,5 +583,38 @@ export default {
         randomId: "ID único ordenável",
       },
     },
+  },
+
+  // Clientes conectados
+  clients: {
+    title: "Clientes Conectados",
+    allClients: "Todos os Clientes",
+    totalCount: "{{count}} clientes no total",
+    noClients: "Nenhum cliente conectado.",
+    name: "Nome",
+    created: "Criado em",
+    lastUsed: "Último uso",
+    status: "Status",
+    actions: "Ações",
+    revoke: "Revogar",
+    revokeConfirm: "Tem certeza que deseja revogar este token?",
+    active: "Ativo",
+    revoked: "Revogado",
+    neverUsed: "Nunca",
+  },
+
+  // Autorização de dispositivo
+  deviceApprove: {
+    title: "Autorização de Dispositivo",
+    description:
+      "Um cliente CLI está solicitando acesso à sua instância Lunar.",
+    userCode: "Verifique se este código corresponde ao do seu CLI:",
+    allow: "Permitir",
+    deny: "Negar",
+    approved:
+      "Cliente CLI autorizado com sucesso. Você pode fechar esta página.",
+    denied: "Acesso negado. O CLI não será autorizado.",
+    expired: "Esta solicitação de autorização expirou ou é inválida.",
+    notFound: "Solicitação de autorização não encontrada.",
   },
 };

--- a/frontend/js/routes.js
+++ b/frontend/js/routes.js
@@ -83,6 +83,19 @@ export const routes = {
   execution: (id) => `#!/executions/${id}`,
 
   /**
+   * Device authorization approval page.
+   * @param {string} code - Device code
+   * @returns {string} Route URL
+   */
+  deviceApprove: (code) => `#!/device-approve/${code}`,
+
+  /**
+   * Connected clients page.
+   * @returns {string} Route URL
+   */
+  clients: () => "#!/clients",
+
+  /**
    * Login page.
    * @returns {string} Route URL
    */
@@ -179,6 +192,19 @@ export const paths = {
    * @returns {string} Path
    */
   execution: (id) => `/executions/${id}`,
+
+  /**
+   * Device authorization approval page.
+   * @param {string} code - Device code
+   * @returns {string} Path
+   */
+  deviceApprove: (code) => `/device-approve/${code}`,
+
+  /**
+   * Connected clients page.
+   * @returns {string} Path
+   */
+  clients: () => "/clients",
 
   /**
    * Login page.

--- a/frontend/js/views/connected-clients.js
+++ b/frontend/js/views/connected-clients.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Connected clients view for managing API tokens.
+ */
+
+import { API } from "../api.js";
+import { t } from "../i18n/index.js";
+import { Button, ButtonVariant } from "../components/button.js";
+import { Card, CardContent, CardHeader } from "../components/card.js";
+import { Badge, BadgeSize, BadgeVariant } from "../components/badge.js";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/table.js";
+
+function formatDate(timestamp) {
+  if (!timestamp) return t("clients.neverUsed");
+  return new Date(timestamp * 1000).toLocaleString();
+}
+
+export const ConnectedClients = {
+  oninit() {
+    this.tokens = [];
+    this.loading = true;
+    this.error = null;
+    this.loadTokens();
+  },
+
+  async loadTokens() {
+    try {
+      const response = await API.tokens.list();
+      this.tokens = response.tokens || [];
+      this.loading = false;
+    } catch (e) {
+      this.error = e.message;
+      this.loading = false;
+    }
+    m.redraw();
+  },
+
+  async revokeToken(id) {
+    if (!confirm(t("clients.revokeConfirm"))) return;
+    try {
+      await API.tokens.revoke(id);
+      await this.loadTokens();
+    } catch (e) {
+      this.error = e.message;
+      m.redraw();
+    }
+  },
+
+  view() {
+    return m(".fade-in", [
+      m(".page-header", [
+        m(".page-header__title", [
+          m("div", [
+            m("h1", t("clients.title")),
+          ]),
+        ]),
+      ]),
+
+      m(Card, [
+        m(CardHeader, {
+          title: t("clients.allClients"),
+          subtitle: t("clients.totalCount", { count: this.tokens.length }),
+        }),
+
+        this.loading
+          ? m(CardContent, m("p", t("common.loading")))
+          : this.error
+          ? m(CardContent, m("p.text--danger", this.error))
+          : this.tokens.length === 0
+          ? m(CardContent, m("p.text-muted", t("clients.noClients")))
+          : m(Table, [
+            m(TableHeader, [
+              m(TableRow, [
+                m(TableHead, t("clients.name")),
+                m(TableHead, t("clients.created")),
+                m(TableHead, t("clients.lastUsed")),
+                m(TableHead, t("clients.status")),
+                m(TableHead, t("clients.actions")),
+              ]),
+            ]),
+            m(
+              TableBody,
+              this.tokens.map((token) =>
+                m(TableRow, { key: token.id }, [
+                  m(TableCell, { mono: true }, token.name),
+                  m(TableCell, formatDate(token.created_at)),
+                  m(TableCell, formatDate(token.last_used)),
+                  m(
+                    TableCell,
+                    m(
+                      Badge,
+                      {
+                        variant: token.revoked
+                          ? BadgeVariant.DEFAULT
+                          : BadgeVariant.SUCCESS,
+                        size: BadgeSize.SM,
+                      },
+                      token.revoked
+                        ? t("clients.revoked")
+                        : t("clients.active"),
+                    ),
+                  ),
+                  m(
+                    TableCell,
+                    !token.revoked &&
+                      m(
+                        Button,
+                        {
+                          variant: ButtonVariant.DESTRUCTIVE,
+                          size: "sm",
+                          onclick: (e) => {
+                            e.stopPropagation();
+                            this.revokeToken(token.id);
+                          },
+                        },
+                        t("clients.revoke"),
+                      ),
+                  ),
+                ])
+              ),
+            ),
+          ]),
+      ]),
+    ]);
+  },
+};

--- a/frontend/js/views/device-approve.js
+++ b/frontend/js/views/device-approve.js
@@ -10,7 +10,11 @@ import { Card, CardContent, CardHeader } from "../components/card.js";
 import { CodeDisplay } from "../components/code-display.js";
 
 function renderContainer(...children) {
-  return m(".centered-page", m(".centered-page__card", children));
+  return m(
+    ".fade-in",
+    { style: "max-width: 480px; margin: 0 auto;" },
+    children,
+  );
 }
 
 export const DeviceApprove = {
@@ -53,17 +57,19 @@ export const DeviceApprove = {
   view() {
     if (this.loading) {
       return renderContainer(
-        m(Card, m(CardContent, m("p", t("common.loading")))),
+        m(Card, [
+          m(CardHeader, { title: t("deviceApprove.title") }),
+          m(CardContent, m("p", t("common.loading"))),
+        ]),
       );
     }
 
     if (this.error) {
       return renderContainer(
-        m(
-          Card,
+        m(Card, [
           m(CardHeader, { title: t("deviceApprove.title") }),
           m(CardContent, m("p.text--danger", this.error)),
-        ),
+        ]),
       );
     }
 
@@ -73,27 +79,24 @@ export const DeviceApprove = {
         : t("deviceApprove.denied");
 
       return renderContainer(
-        m(
-          Card,
+        m(Card, [
           m(CardHeader, { title: t("deviceApprove.title") }),
           m(CardContent, m("p", message)),
-        ),
+        ]),
       );
     }
 
     if (this.auth.status !== "pending") {
       return renderContainer(
-        m(
-          Card,
+        m(Card, [
           m(CardHeader, { title: t("deviceApprove.title") }),
           m(CardContent, m("p", t("deviceApprove.expired"))),
-        ),
+        ]),
       );
     }
 
     return renderContainer(
-      m(
-        Card,
+      m(Card, [
         m(CardHeader, { title: t("deviceApprove.title") }),
         m(CardContent, [
           m(
@@ -133,7 +136,7 @@ export const DeviceApprove = {
             ],
           ),
         ]),
-      ),
+      ]),
     );
   },
 };

--- a/frontend/js/views/device-approve.js
+++ b/frontend/js/views/device-approve.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Device authorization approval view.
+ * Allows logged-in users to approve or deny CLI device auth requests.
+ */
+
+import { API } from "../api.js";
+import { t } from "../i18n/index.js";
+import { Button, ButtonVariant } from "../components/button.js";
+import { Card, CardContent, CardHeader } from "../components/card.js";
+import { CodeDisplay } from "../components/code-display.js";
+
+function renderContainer(...children) {
+  return m(".centered-page", m(".centered-page__card", children));
+}
+
+export const DeviceApprove = {
+  oninit(vnode) {
+    this.code = vnode.attrs.code;
+    this.loading = true;
+    this.error = null;
+    this.auth = null;
+    this.completed = false;
+    this.completedAction = null;
+    this.submitting = false;
+
+    this.loadStatus();
+  },
+
+  async loadStatus() {
+    try {
+      this.auth = await API.auth.getDeviceApproveStatus(this.code);
+      this.loading = false;
+    } catch (e) {
+      this.error = e.message || t("deviceApprove.notFound");
+      this.loading = false;
+    }
+    m.redraw();
+  },
+
+  async handleAction(action) {
+    this.submitting = true;
+    try {
+      await API.auth.approveDevice(this.code, action);
+      this.completed = true;
+      this.completedAction = action;
+    } catch (e) {
+      this.error = e.message;
+    }
+    this.submitting = false;
+    m.redraw();
+  },
+
+  view() {
+    if (this.loading) {
+      return renderContainer(
+        m(Card, m(CardContent, m("p", t("common.loading")))),
+      );
+    }
+
+    if (this.error) {
+      return renderContainer(
+        m(
+          Card,
+          m(CardHeader, { title: t("deviceApprove.title") }),
+          m(CardContent, m("p.text--danger", this.error)),
+        ),
+      );
+    }
+
+    if (this.completed) {
+      const message = this.completedAction === "allow"
+        ? t("deviceApprove.approved")
+        : t("deviceApprove.denied");
+
+      return renderContainer(
+        m(
+          Card,
+          m(CardHeader, { title: t("deviceApprove.title") }),
+          m(CardContent, m("p", message)),
+        ),
+      );
+    }
+
+    if (this.auth.status !== "pending") {
+      return renderContainer(
+        m(
+          Card,
+          m(CardHeader, { title: t("deviceApprove.title") }),
+          m(CardContent, m("p", t("deviceApprove.expired"))),
+        ),
+      );
+    }
+
+    return renderContainer(
+      m(
+        Card,
+        m(CardHeader, { title: t("deviceApprove.title") }),
+        m(CardContent, [
+          m(
+            "p",
+            { style: "margin-bottom: 1.5rem;" },
+            t("deviceApprove.description"),
+          ),
+          m(CodeDisplay, {
+            label: t("deviceApprove.userCode"),
+            value: this.auth.user_code,
+          }),
+          m(
+            "div",
+            {
+              style:
+                "display: flex; gap: 0.75rem; justify-content: flex-end; margin-top: 1.5rem;",
+            },
+            [
+              m(
+                Button,
+                {
+                  variant: ButtonVariant.SECONDARY,
+                  onclick: () => this.handleAction("deny"),
+                  disabled: this.submitting,
+                },
+                t("deviceApprove.deny"),
+              ),
+              m(
+                Button,
+                {
+                  variant: ButtonVariant.PRIMARY,
+                  onclick: () => this.handleAction("allow"),
+                  disabled: this.submitting,
+                },
+                t("deviceApprove.allow"),
+              ),
+            ],
+          ),
+        ]),
+      ),
+    );
+  },
+};

--- a/frontend/js/views/preview.js
+++ b/frontend/js/views/preview.js
@@ -74,6 +74,7 @@ import {
 import { AIRequestViewer } from "../components/ai-request-viewer.js";
 import { EmailRequestViewer } from "../components/email-request-viewer.js";
 import { CodeEditor } from "../components/code-editor.js";
+import { CodeDisplay } from "../components/code-display.js";
 
 /**
  * @typedef {import('../components/env-editor.js').EnvVar} EnvVar
@@ -180,6 +181,7 @@ export const Preview = {
     "diff-viewer",
     "ai-request-viewer",
     "email-request-viewer",
+    "code-display",
   ],
 
   /**
@@ -263,6 +265,8 @@ export const Preview = {
         return Preview.renderAIRequestViewer();
       case "email-request-viewer":
         return Preview.renderEmailRequestViewer();
+      case "code-display":
+        return Preview.renderCodeDisplay();
       default:
         return m("p", "Component not found");
     }
@@ -1262,6 +1266,43 @@ end`;
       m(Card, { style: "max-width: 900px;" }, [
         m(CardContent, { noPadding: true }, [
           m(EmailRequestViewer, { requests: [], noBorder: true }),
+        ]),
+      ]),
+    ]);
+  },
+
+  /**
+   * Renders code display component previews.
+   * @returns {Object} Mithril vnode
+   */
+  renderCodeDisplay: () => {
+    return m(".preview-section", [
+      m("h3", "With Label"),
+      m(Card, { style: "max-width: 400px; margin-bottom: 1rem;" }, [
+        m(CardContent, [
+          m(CodeDisplay, {
+            label: "Verification Code",
+            value: "ABCD-1234",
+          }),
+        ]),
+      ]),
+
+      m("h3", "Without Label"),
+      m(Card, { style: "max-width: 400px; margin-bottom: 1rem;" }, [
+        m(CardContent, [
+          m(CodeDisplay, {
+            value: "XKCD-9876",
+          }),
+        ]),
+      ]),
+
+      m("h3", "Long Code"),
+      m(Card, { style: "max-width: 400px;" }, [
+        m(CardContent, [
+          m(CodeDisplay, {
+            label: "Device Code",
+            value: "A1B2-C3D4-E5F6",
+          }),
         ]),
       ]),
     ]);

--- a/frontend/test/spec/components/command-palette.spec.js
+++ b/frontend/test/spec/components/command-palette.spec.js
@@ -106,6 +106,17 @@ describe("CommandPalette", () => {
       expect(createItem).toBeTruthy();
     });
 
+    it("includes clients nav item", () => {
+      CommandPalette.query = "";
+      CommandPalette.updateResults();
+
+      const clientsItem = CommandPalette.results.find(
+        (r) => r.type === "nav" && r.path === "/clients",
+      );
+      expect(clientsItem).toBeTruthy();
+      expect(clientsItem.icon).toBe("network");
+    });
+
     it("resets selectedIndex when out of bounds", () => {
       CommandPalette.query = "";
       CommandPalette.updateResults();

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -3,15 +3,21 @@ package api
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/dimiro1/lunar/internal/store"
+	"github.com/dimiro1/lunar/internal/token"
 )
 
-// AuthMiddleware validates authentication via cookie or Bearer token
-func AuthMiddleware(apiKey string) func(http.Handler) http.Handler {
+// AuthMiddleware validates authentication via cookie or Bearer token.
+// It checks the admin API key first, then falls back to API tokens in the database.
+func AuthMiddleware(apiKey string, db store.DB) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Check cookie first
+			// Check cookie first (always uses admin API key)
 			if cookie, err := r.Cookie("auth_token"); err == nil {
 				if isValidAPIKey(cookie.Value, apiKey) {
 					next.ServeHTTP(w, r)
@@ -25,7 +31,24 @@ func AuthMiddleware(apiKey string) func(http.Handler) http.Handler {
 				// Expected format: "Bearer {token}"
 				parts := strings.SplitN(authHeader, " ", 2)
 				if len(parts) == 2 && parts[0] == "Bearer" {
-					if isValidAPIKey(parts[1], apiKey) {
+					bearerToken := parts[1]
+
+					// First check against admin API key
+					if isValidAPIKey(bearerToken, apiKey) {
+						next.ServeHTTP(w, r)
+						return
+					}
+
+					// Then check against API tokens in the database
+					tokenHash := token.Hash(bearerToken)
+					apiToken, err := db.GetAPITokenByHash(r.Context(), tokenHash)
+					if err == nil {
+						// Valid token found, update last_used asynchronously
+						go func() {
+							if err := db.UpdateAPITokenLastUsed(r.Context(), apiToken.ID, time.Now().Unix()); err != nil {
+								slog.Error("Failed to update API token last_used", "error", err)
+							}
+						}()
 						next.ServeHTTP(w, r)
 						return
 					}

--- a/internal/api/device_auth_handlers.go
+++ b/internal/api/device_auth_handlers.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/dimiro1/lunar/internal/store"
+	"github.com/dimiro1/lunar/internal/token"
+	"github.com/rs/xid"
+)
+
+const (
+	deviceCodeExpiry = 5 * time.Minute
+	userCodeChars    = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no I, O, 0, 1 to avoid confusion
+	userCodeLength   = 8
+)
+
+// PendingAuthStatus represents the status of a pending device auth request
+type PendingAuthStatus string
+
+const (
+	PendingAuthStatusPending  PendingAuthStatus = "pending"
+	PendingAuthStatusApproved PendingAuthStatus = "approved"
+	PendingAuthStatusDenied   PendingAuthStatus = "denied"
+)
+
+// PendingAuth represents a pending device authorization request
+type PendingAuth struct {
+	DeviceCode string
+	UserCode   string
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	Status     PendingAuthStatus
+	Token      string // raw token, set on approval
+}
+
+// DeviceAuthStore is a thread-safe in-memory store for pending device auth requests.
+// Pending auths are stored in memory rather than the database because they are
+// short-lived (5 minute TTL) and do not need to survive server restarts.
+type DeviceAuthStore struct {
+	mu      sync.Mutex
+	pending map[string]*PendingAuth // keyed by device_code
+}
+
+// NewDeviceAuthStore creates a new DeviceAuthStore
+func NewDeviceAuthStore() *DeviceAuthStore {
+	return &DeviceAuthStore{
+		pending: make(map[string]*PendingAuth),
+	}
+}
+
+// cleanupExpired removes all expired entries from the pending map.
+// Must be called with s.mu held.
+func (s *DeviceAuthStore) cleanupExpired() {
+	now := time.Now()
+	for code, auth := range s.pending {
+		if now.After(auth.ExpiresAt) {
+			delete(s.pending, code)
+		}
+	}
+}
+
+// Create generates a new pending auth request and returns it
+func (s *DeviceAuthStore) Create() *PendingAuth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cleanupExpired()
+
+	now := time.Now()
+	auth := &PendingAuth{
+		DeviceCode: xid.New().String(),
+		UserCode:   generateUserCode(),
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(deviceCodeExpiry),
+		Status:     PendingAuthStatusPending,
+	}
+
+	s.pending[auth.DeviceCode] = auth
+	return auth
+}
+
+// Get returns a pending auth by device code, or nil if not found/expired
+func (s *DeviceAuthStore) Get(deviceCode string) *PendingAuth {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	auth, ok := s.pending[deviceCode]
+	if !ok {
+		return nil
+	}
+
+	if time.Now().After(auth.ExpiresAt) {
+		delete(s.pending, deviceCode)
+		return nil
+	}
+
+	return auth
+}
+
+// getPending returns a pending auth by device code if it exists, is not expired,
+// and is still in pending status. Must be called with s.mu held.
+func (s *DeviceAuthStore) getPending(deviceCode string) *PendingAuth {
+	auth, ok := s.pending[deviceCode]
+	if !ok || time.Now().After(auth.ExpiresAt) || auth.Status != PendingAuthStatusPending {
+		return nil
+	}
+	return auth
+}
+
+// Approve marks a pending auth as approved with the given token
+func (s *DeviceAuthStore) Approve(deviceCode string, token string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	auth := s.getPending(deviceCode)
+	if auth == nil {
+		return false
+	}
+
+	auth.Status = PendingAuthStatusApproved
+	auth.Token = token
+	return true
+}
+
+// Deny marks a pending auth as denied
+func (s *DeviceAuthStore) Deny(deviceCode string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	auth := s.getPending(deviceCode)
+	if auth == nil {
+		return false
+	}
+
+	auth.Status = PendingAuthStatusDenied
+	return true
+}
+
+func generateUserCode() string {
+	code := make([]byte, userCodeLength)
+	for i := range code {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(userCodeChars))))
+		code[i] = userCodeChars[n.Int64()]
+	}
+	return string(code)
+}
+
+// HandleDeviceRequest handles POST /api/auth/device-request
+// No auth required - the CLI is not yet authenticated
+func HandleDeviceRequest(deviceStore *DeviceAuthStore, baseURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		auth := deviceStore.Create()
+
+		writeJSON(w, http.StatusOK, DeviceRequestResponse{
+			DeviceCode:  auth.DeviceCode,
+			UserCode:    auth.UserCode,
+			ApprovalURL: baseURL + "/#!/device-approve/" + auth.DeviceCode,
+			ExpiresIn:   int(deviceCodeExpiry.Seconds()),
+			Interval:    5,
+		})
+	}
+}
+
+// HandleDeviceApproveStatus handles GET /api/auth/device-approve?code=<device_code>
+// Auth required - returns pending request info for the SPA to render
+func HandleDeviceApproveStatus(deviceStore *DeviceAuthStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			writeError(w, http.StatusBadRequest, "Missing code parameter")
+			return
+		}
+
+		auth := deviceStore.Get(code)
+		if auth == nil {
+			writeError(w, http.StatusNotFound, "Device code not found or expired")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, DeviceApproveStatusResponse{
+			DeviceCode: auth.DeviceCode,
+			UserCode:   auth.UserCode,
+			Status:     string(auth.Status),
+			ExpiresAt:  auth.ExpiresAt.Unix(),
+		})
+	}
+}
+
+// HandleDeviceApprove handles POST /api/auth/device-approve
+// Auth required - user approves or denies the request
+func HandleDeviceApprove(deviceStore *DeviceAuthStore, db store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req DeviceApproveRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+
+		if req.DeviceCode == "" {
+			writeError(w, http.StatusBadRequest, "Missing device_code")
+			return
+		}
+
+		switch req.Action {
+		case "allow":
+			rawToken, err := token.Generate()
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "Failed to generate token")
+				return
+			}
+
+			tokenHash := token.Hash(rawToken)
+
+			auth := deviceStore.Get(req.DeviceCode)
+			if auth == nil {
+				writeError(w, http.StatusNotFound, "Device code not found or expired")
+				return
+			}
+
+			_, err = db.CreateAPIToken(r.Context(), store.APIToken{
+				ID:        xid.New().String(),
+				TokenHash: tokenHash,
+				Name:      "CLI (" + auth.UserCode + ")",
+			})
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "Failed to create token")
+				return
+			}
+
+			if !deviceStore.Approve(req.DeviceCode, rawToken) {
+				writeError(w, http.StatusNotFound, "Device code not found or expired")
+				return
+			}
+
+			writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+
+		case "deny":
+			if !deviceStore.Deny(req.DeviceCode) {
+				writeError(w, http.StatusNotFound, "Device code not found or expired")
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+
+		default:
+			writeError(w, http.StatusBadRequest, "Invalid action, must be 'allow' or 'deny'")
+		}
+	}
+}
+
+// HandleDeviceToken handles GET /api/auth/device-token?code=<device_code>
+// No auth required - polled by CLI
+func HandleDeviceToken(deviceStore *DeviceAuthStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			writeError(w, http.StatusBadRequest, "Missing code parameter")
+			return
+		}
+
+		auth := deviceStore.Get(code)
+		if auth == nil {
+			writeError(w, http.StatusNotFound, "Device code not found or expired")
+			return
+		}
+
+		switch auth.Status {
+		case PendingAuthStatusApproved:
+			writeJSON(w, http.StatusOK, DeviceTokenResponse{
+				Status: string(PendingAuthStatusApproved),
+				Token:  auth.Token,
+			})
+		case PendingAuthStatusDenied:
+			writeJSON(w, http.StatusOK, DeviceTokenResponse{
+				Status: string(PendingAuthStatusDenied),
+			})
+		default:
+			writeJSON(w, http.StatusOK, DeviceTokenResponse{
+				Status: string(PendingAuthStatusPending),
+			})
+		}
+	}
+}
+
+// HandleListAPITokens handles GET /api/tokens
+func HandleListAPITokens(db store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokens, err := db.ListAPITokens(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to list tokens")
+			return
+		}
+
+		if tokens == nil {
+			tokens = []store.APIToken{}
+		}
+
+		writeJSON(w, http.StatusOK, map[string][]store.APIToken{"tokens": tokens})
+	}
+}
+
+// HandleRevokeAPIToken handles POST /api/tokens/{id}/revoke
+func HandleRevokeAPIToken(db store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "Missing token ID")
+			return
+		}
+
+		err := db.RevokeAPIToken(r.Context(), id)
+		if err != nil {
+			if err == store.ErrAPITokenNotFound {
+				writeError(w, http.StatusNotFound, "Token not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "Failed to revoke token")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+	}
+}

--- a/internal/api/device_auth_handlers_test.go
+++ b/internal/api/device_auth_handlers_test.go
@@ -136,7 +136,9 @@ func TestHandleDeviceToken_Pending(t *testing.T) {
 	server.Handler().ServeHTTP(wCreate, reqCreate)
 
 	var createResp DeviceRequestResponse
-	json.NewDecoder(wCreate.Body).Decode(&createResp)
+	if err := json.NewDecoder(wCreate.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
 
 	// Poll for token - should be pending
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code="+createResp.DeviceCode, nil)
@@ -148,7 +150,9 @@ func TestHandleDeviceToken_Pending(t *testing.T) {
 	}
 
 	var tokenResp DeviceTokenResponse
-	json.NewDecoder(w.Body).Decode(&tokenResp)
+	if err := json.NewDecoder(w.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("failed to decode token response: %v", err)
+	}
 
 	if tokenResp.Status != "pending" {
 		t.Errorf("expected status pending, got %s", tokenResp.Status)
@@ -192,7 +196,9 @@ func TestHandleDeviceApproveFlow(t *testing.T) {
 	server.Handler().ServeHTTP(wCreate, reqCreate)
 
 	var createResp DeviceRequestResponse
-	json.NewDecoder(wCreate.Body).Decode(&createResp)
+	if err := json.NewDecoder(wCreate.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
 
 	// Step 2: Get approve status (requires auth)
 	reqStatus := makeAuthRequest(http.MethodGet, "/api/auth/device-approve?code="+createResp.DeviceCode, nil)
@@ -204,7 +210,9 @@ func TestHandleDeviceApproveFlow(t *testing.T) {
 	}
 
 	var statusResp DeviceApproveStatusResponse
-	json.NewDecoder(wStatus.Body).Decode(&statusResp)
+	if err := json.NewDecoder(wStatus.Body).Decode(&statusResp); err != nil {
+		t.Fatalf("failed to decode status response: %v", err)
+	}
 
 	if statusResp.Status != "pending" {
 		t.Errorf("expected status pending, got %s", statusResp.Status)
@@ -239,7 +247,9 @@ func TestHandleDeviceApproveFlow(t *testing.T) {
 	}
 
 	var tokenResp DeviceTokenResponse
-	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+	if err := json.NewDecoder(wToken.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("failed to decode token response: %v", err)
+	}
 
 	if tokenResp.Status != "approved" {
 		t.Errorf("expected status approved, got %s", tokenResp.Status)
@@ -269,7 +279,9 @@ func TestHandleDeviceDenyFlow(t *testing.T) {
 	server.Handler().ServeHTTP(wCreate, reqCreate)
 
 	var createResp DeviceRequestResponse
-	json.NewDecoder(wCreate.Body).Decode(&createResp)
+	if err := json.NewDecoder(wCreate.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
 
 	// Deny the request
 	denyBody, _ := json.Marshal(DeviceApproveRequest{
@@ -290,7 +302,9 @@ func TestHandleDeviceDenyFlow(t *testing.T) {
 	server.Handler().ServeHTTP(wToken, reqToken)
 
 	var tokenResp DeviceTokenResponse
-	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+	if err := json.NewDecoder(wToken.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("failed to decode token response: %v", err)
+	}
 
 	if tokenResp.Status != "denied" {
 		t.Errorf("expected status denied, got %s", tokenResp.Status)
@@ -334,7 +348,9 @@ func TestHandleDeviceApprove_InvalidAction(t *testing.T) {
 	server.Handler().ServeHTTP(wCreate, reqCreate)
 
 	var createResp DeviceRequestResponse
-	json.NewDecoder(wCreate.Body).Decode(&createResp)
+	if err := json.NewDecoder(wCreate.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
 
 	// Try invalid action
 	body, _ := json.Marshal(DeviceApproveRequest{
@@ -364,7 +380,9 @@ func TestHandleListAPITokens(t *testing.T) {
 	}
 
 	var resp map[string][]store.APIToken
-	json.NewDecoder(w.Body).Decode(&resp)
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
 
 	if len(resp["tokens"]) != 0 {
 		t.Errorf("expected 0 tokens, got %d", len(resp["tokens"]))
@@ -381,7 +399,9 @@ func TestHandleRevokeAPIToken(t *testing.T) {
 	server.Handler().ServeHTTP(wCreate, reqCreate)
 
 	var createResp DeviceRequestResponse
-	json.NewDecoder(wCreate.Body).Decode(&createResp)
+	if err := json.NewDecoder(wCreate.Body).Decode(&createResp); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
 
 	// Approve
 	approveBody, _ := json.Marshal(DeviceApproveRequest{
@@ -398,7 +418,9 @@ func TestHandleRevokeAPIToken(t *testing.T) {
 	server.Handler().ServeHTTP(wToken, reqToken)
 
 	var tokenResp DeviceTokenResponse
-	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+	if err := json.NewDecoder(wToken.Body).Decode(&tokenResp); err != nil {
+		t.Fatalf("failed to decode token response: %v", err)
+	}
 
 	// List tokens to get the ID
 	reqList := makeAuthRequest(http.MethodGet, "/api/tokens", nil)
@@ -406,7 +428,9 @@ func TestHandleRevokeAPIToken(t *testing.T) {
 	server.Handler().ServeHTTP(wList, reqList)
 
 	var listResp map[string][]store.APIToken
-	json.NewDecoder(wList.Body).Decode(&listResp)
+	if err := json.NewDecoder(wList.Body).Decode(&listResp); err != nil {
+		t.Fatalf("failed to decode list response: %v", err)
+	}
 
 	if len(listResp["tokens"]) != 1 {
 		t.Fatalf("expected 1 token, got %d", len(listResp["tokens"]))

--- a/internal/api/device_auth_handlers_test.go
+++ b/internal/api/device_auth_handlers_test.go
@@ -1,0 +1,517 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dimiro1/lunar/internal/store"
+	"github.com/dimiro1/lunar/internal/token"
+)
+
+func TestDeviceAuthStore_CreateAndGet(t *testing.T) {
+	ds := NewDeviceAuthStore()
+
+	auth := ds.Create()
+	if auth.DeviceCode == "" {
+		t.Error("expected DeviceCode to be set")
+	}
+	if auth.UserCode == "" {
+		t.Error("expected UserCode to be set")
+	}
+	if len(auth.UserCode) != userCodeLength {
+		t.Errorf("expected UserCode length %d, got %d", userCodeLength, len(auth.UserCode))
+	}
+	if auth.Status != PendingAuthStatusPending {
+		t.Errorf("expected status pending, got %s", auth.Status)
+	}
+
+	// Should be retrievable
+	found := ds.Get(auth.DeviceCode)
+	if found == nil {
+		t.Fatal("expected to find pending auth")
+	}
+	if found.DeviceCode != auth.DeviceCode {
+		t.Errorf("expected DeviceCode %s, got %s", auth.DeviceCode, found.DeviceCode)
+	}
+}
+
+func TestDeviceAuthStore_GetNotFound(t *testing.T) {
+	ds := NewDeviceAuthStore()
+
+	found := ds.Get("nonexistent")
+	if found != nil {
+		t.Error("expected nil for nonexistent device code")
+	}
+}
+
+func TestDeviceAuthStore_ApproveAndDeny(t *testing.T) {
+	ds := NewDeviceAuthStore()
+
+	// Test approve
+	auth := ds.Create()
+	ok := ds.Approve(auth.DeviceCode, "test-token-value")
+	if !ok {
+		t.Error("expected Approve to succeed")
+	}
+
+	found := ds.Get(auth.DeviceCode)
+	if found.Status != PendingAuthStatusApproved {
+		t.Errorf("expected status approved, got %s", found.Status)
+	}
+	if found.Token != "test-token-value" {
+		t.Errorf("expected token test-token-value, got %s", found.Token)
+	}
+
+	// Test deny
+	auth2 := ds.Create()
+	ok = ds.Deny(auth2.DeviceCode)
+	if !ok {
+		t.Error("expected Deny to succeed")
+	}
+
+	found2 := ds.Get(auth2.DeviceCode)
+	if found2.Status != PendingAuthStatusDenied {
+		t.Errorf("expected status denied, got %s", found2.Status)
+	}
+}
+
+func TestDeviceAuthStore_DoubleApprove(t *testing.T) {
+	ds := NewDeviceAuthStore()
+
+	auth := ds.Create()
+	ds.Approve(auth.DeviceCode, "token1")
+
+	// Second approve should fail
+	ok := ds.Approve(auth.DeviceCode, "token2")
+	if ok {
+		t.Error("expected second Approve to fail")
+	}
+}
+
+func TestHandleDeviceRequest(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	w := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp DeviceRequestResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.DeviceCode == "" {
+		t.Error("expected device_code to be set")
+	}
+	if resp.UserCode == "" {
+		t.Error("expected user_code to be set")
+	}
+	if resp.ApprovalURL == "" {
+		t.Error("expected approval_url to be set")
+	}
+	if resp.ExpiresIn != 300 {
+		t.Errorf("expected expires_in 300, got %d", resp.ExpiresIn)
+	}
+	if resp.Interval != 5 {
+		t.Errorf("expected interval 5, got %d", resp.Interval)
+	}
+}
+
+func TestHandleDeviceToken_Pending(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// First create a device request
+	reqCreate := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	wCreate := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wCreate, reqCreate)
+
+	var createResp DeviceRequestResponse
+	json.NewDecoder(wCreate.Body).Decode(&createResp)
+
+	// Poll for token - should be pending
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code="+createResp.DeviceCode, nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var tokenResp DeviceTokenResponse
+	json.NewDecoder(w.Body).Decode(&tokenResp)
+
+	if tokenResp.Status != "pending" {
+		t.Errorf("expected status pending, got %s", tokenResp.Status)
+	}
+	if tokenResp.Token != "" {
+		t.Error("expected token to be empty for pending status")
+	}
+}
+
+func TestHandleDeviceToken_NotFound(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code=nonexistent", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeviceToken_MissingCode(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/device-token", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", w.Code)
+	}
+}
+
+func TestHandleDeviceApproveFlow(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// Step 1: Create device request
+	reqCreate := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	wCreate := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wCreate, reqCreate)
+
+	var createResp DeviceRequestResponse
+	json.NewDecoder(wCreate.Body).Decode(&createResp)
+
+	// Step 2: Get approve status (requires auth)
+	reqStatus := makeAuthRequest(http.MethodGet, "/api/auth/device-approve?code="+createResp.DeviceCode, nil)
+	wStatus := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wStatus, reqStatus)
+
+	if wStatus.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for approve status, got %d: %s", wStatus.Code, wStatus.Body.String())
+	}
+
+	var statusResp DeviceApproveStatusResponse
+	json.NewDecoder(wStatus.Body).Decode(&statusResp)
+
+	if statusResp.Status != "pending" {
+		t.Errorf("expected status pending, got %s", statusResp.Status)
+	}
+	if statusResp.UserCode == "" {
+		t.Error("expected user_code to be set")
+	}
+	if statusResp.DeviceCode != createResp.DeviceCode {
+		t.Errorf("expected device_code %s, got %s", createResp.DeviceCode, statusResp.DeviceCode)
+	}
+
+	// Step 3: Approve the request (requires auth)
+	approveBody, _ := json.Marshal(DeviceApproveRequest{
+		DeviceCode: createResp.DeviceCode,
+		Action:     "allow",
+	})
+	reqApprove := makeAuthRequest(http.MethodPost, "/api/auth/device-approve", approveBody)
+	wApprove := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wApprove, reqApprove)
+
+	if wApprove.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for approve, got %d: %s", wApprove.Code, wApprove.Body.String())
+	}
+
+	// Step 4: Poll for token - should now be approved
+	reqToken := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code="+createResp.DeviceCode, nil)
+	wToken := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wToken, reqToken)
+
+	if wToken.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for token, got %d: %s", wToken.Code, wToken.Body.String())
+	}
+
+	var tokenResp DeviceTokenResponse
+	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+
+	if tokenResp.Status != "approved" {
+		t.Errorf("expected status approved, got %s", tokenResp.Status)
+	}
+	if tokenResp.Token == "" {
+		t.Error("expected token to be set")
+	}
+
+	// Step 5: Verify the token works for authentication
+	reqAuth := httptest.NewRequest(http.MethodGet, "/api/functions", nil)
+	reqAuth.Header.Set("Authorization", "Bearer "+tokenResp.Token)
+	wAuth := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wAuth, reqAuth)
+
+	if wAuth.Code != http.StatusOK {
+		t.Errorf("expected status 200 with API token auth, got %d: %s", wAuth.Code, wAuth.Body.String())
+	}
+}
+
+func TestHandleDeviceDenyFlow(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// Create device request
+	reqCreate := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	wCreate := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wCreate, reqCreate)
+
+	var createResp DeviceRequestResponse
+	json.NewDecoder(wCreate.Body).Decode(&createResp)
+
+	// Deny the request
+	denyBody, _ := json.Marshal(DeviceApproveRequest{
+		DeviceCode: createResp.DeviceCode,
+		Action:     "deny",
+	})
+	reqDeny := makeAuthRequest(http.MethodPost, "/api/auth/device-approve", denyBody)
+	wDeny := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wDeny, reqDeny)
+
+	if wDeny.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for deny, got %d: %s", wDeny.Code, wDeny.Body.String())
+	}
+
+	// Poll for token - should be denied
+	reqToken := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code="+createResp.DeviceCode, nil)
+	wToken := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wToken, reqToken)
+
+	var tokenResp DeviceTokenResponse
+	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+
+	if tokenResp.Status != "denied" {
+		t.Errorf("expected status denied, got %s", tokenResp.Status)
+	}
+	if tokenResp.Token != "" {
+		t.Error("expected token to be empty for denied status")
+	}
+}
+
+func TestHandleDeviceApprove_RequiresAuth(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	// GET approve status without auth
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/device-approve?code=test", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 for unauthenticated approve status, got %d", w.Code)
+	}
+
+	// POST approve without auth
+	body, _ := json.Marshal(DeviceApproveRequest{DeviceCode: "test", Action: "allow"})
+	reqPost := httptest.NewRequest(http.MethodPost, "/api/auth/device-approve", bytes.NewReader(body))
+	reqPost.Header.Set("Content-Type", "application/json")
+	wPost := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wPost, reqPost)
+
+	if wPost.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 for unauthenticated approve, got %d", wPost.Code)
+	}
+}
+
+func TestHandleDeviceApprove_InvalidAction(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// Create device request
+	reqCreate := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	wCreate := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wCreate, reqCreate)
+
+	var createResp DeviceRequestResponse
+	json.NewDecoder(wCreate.Body).Decode(&createResp)
+
+	// Try invalid action
+	body, _ := json.Marshal(DeviceApproveRequest{
+		DeviceCode: createResp.DeviceCode,
+		Action:     "invalid",
+	})
+	req := makeAuthRequest(http.MethodPost, "/api/auth/device-approve", body)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid action, got %d", w.Code)
+	}
+}
+
+func TestHandleListAPITokens(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// List should be empty initially
+	req := makeAuthRequest(http.MethodGet, "/api/tokens", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string][]store.APIToken
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if len(resp["tokens"]) != 0 {
+		t.Errorf("expected 0 tokens, got %d", len(resp["tokens"]))
+	}
+}
+
+func TestHandleRevokeAPIToken(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// Create a token via the device flow
+	reqCreate := httptest.NewRequest(http.MethodPost, "/api/auth/device-request", nil)
+	wCreate := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wCreate, reqCreate)
+
+	var createResp DeviceRequestResponse
+	json.NewDecoder(wCreate.Body).Decode(&createResp)
+
+	// Approve
+	approveBody, _ := json.Marshal(DeviceApproveRequest{
+		DeviceCode: createResp.DeviceCode,
+		Action:     "allow",
+	})
+	reqApprove := makeAuthRequest(http.MethodPost, "/api/auth/device-approve", approveBody)
+	wApprove := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wApprove, reqApprove)
+
+	// Get the token from poll
+	reqToken := httptest.NewRequest(http.MethodGet, "/api/auth/device-token?code="+createResp.DeviceCode, nil)
+	wToken := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wToken, reqToken)
+
+	var tokenResp DeviceTokenResponse
+	json.NewDecoder(wToken.Body).Decode(&tokenResp)
+
+	// List tokens to get the ID
+	reqList := makeAuthRequest(http.MethodGet, "/api/tokens", nil)
+	wList := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wList, reqList)
+
+	var listResp map[string][]store.APIToken
+	json.NewDecoder(wList.Body).Decode(&listResp)
+
+	if len(listResp["tokens"]) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(listResp["tokens"]))
+	}
+
+	tokenID := listResp["tokens"][0].ID
+
+	// Revoke the token
+	reqRevoke := makeAuthRequest(http.MethodPost, "/api/tokens/"+tokenID+"/revoke", nil)
+	wRevoke := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wRevoke, reqRevoke)
+
+	if wRevoke.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for revoke, got %d: %s", wRevoke.Code, wRevoke.Body.String())
+	}
+
+	// Verify the token no longer works for auth
+	reqAuth := httptest.NewRequest(http.MethodGet, "/api/functions", nil)
+	reqAuth.Header.Set("Authorization", "Bearer "+tokenResp.Token)
+	wAuth := httptest.NewRecorder()
+	server.Handler().ServeHTTP(wAuth, reqAuth)
+
+	if wAuth.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 after revocation, got %d", wAuth.Code)
+	}
+}
+
+func TestHandleRevokeAPIToken_NotFound(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := makeAuthRequest(http.MethodPost, "/api/tokens/nonexistent/revoke", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", w.Code)
+	}
+}
+
+func TestAuthMiddleware_WithAPIToken(t *testing.T) {
+	database := store.NewMemoryDB()
+	server := createTestServer(database)
+
+	// Create an API token directly in the store
+	rawToken := "test-cli-token-12345678901234567890"
+	tokenHash := token.Hash(rawToken)
+
+	_, err := database.CreateAPIToken(context.Background(), store.APIToken{
+		ID:        "direct_token",
+		TokenHash: tokenHash,
+		Name:      "Test CLI",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	// Use the raw token for auth
+	req := httptest.NewRequest(http.MethodGet, "/api/functions", nil)
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 with API token, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_InvalidToken(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/functions", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 with invalid token, got %d", w.Code)
+	}
+}
+
+func TestAuthMiddleware_AdminKeyStillWorks(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	// Admin API key should still work
+	req := makeAuthRequest(http.MethodGet, "/api/functions", nil)
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 with admin key, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_CookieStillWorks(t *testing.T) {
+	server := createTestServer(store.NewMemoryDB())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/functions", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "auth_token",
+		Value: "test-api-key",
+	})
+	w := httptest.NewRecorder()
+	server.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 with cookie auth, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/docs/openapi.yaml
+++ b/internal/api/docs/openapi.yaml
@@ -26,6 +26,10 @@ tags:
     description: Function execution history and logs
   - name: Runtime
     description: Function execution endpoints
+  - name: Device Authorization
+    description: OAuth 2.0-style device authorization flow for CLI authentication
+  - name: API Tokens
+    description: API token management for connected clients
 
 security:
   - CookieAuth: []
@@ -1063,6 +1067,314 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/auth/device-request:
+    post:
+      tags:
+        - Device Authorization
+      summary: Initiate device authorization flow
+      description: |
+        Starts the device authorization flow. Returns a device code and user code.
+        The CLI opens a browser to the approval URL where the user can authorize the device.
+        This endpoint does not require authentication.
+      operationId: deviceRequest
+      security: []
+      responses:
+        "200":
+          description: Device authorization request created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceRequestResponse"
+              examples:
+                success:
+                  summary: Successful device request
+                  value:
+                    device_code: "crs1abc2def3ghi4"
+                    user_code: "ABCD-EFGH"
+                    approval_url: "http://localhost:3000/#!/device-approve/crs1abc2def3ghi4"
+                    expires_in: 300
+                    interval: 5
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/auth/device-approve:
+    get:
+      tags:
+        - Device Authorization
+      summary: Get device authorization request status
+      description: |
+        Returns the status of a pending device authorization request.
+        Used by the SPA to display the approval page with the user code.
+      operationId: deviceApproveStatus
+      parameters:
+        - name: code
+          in: query
+          required: true
+          description: The device code from the authorization request
+          schema:
+            type: string
+            example: "crs1abc2def3ghi4"
+      responses:
+        "200":
+          description: Device authorization status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceApproveStatusResponse"
+              examples:
+                pending:
+                  summary: Pending approval
+                  value:
+                    device_code: "crs1abc2def3ghi4"
+                    user_code: "ABCD-EFGH"
+                    status: "pending"
+                    expires_at: 1672531500
+        "404":
+          description: Device authorization request not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                notFound:
+                  summary: Request not found
+                  value:
+                    error: "device auth request not found"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    post:
+      tags:
+        - Device Authorization
+      summary: Approve or deny a device authorization request
+      description: |
+        Allows the authenticated user to approve or deny a pending device authorization request.
+        On approval, generates an API token and stores its hash in the database.
+        The raw token is returned to the polling CLI via the device-token endpoint.
+      operationId: deviceApprove
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceApproveRequest"
+            examples:
+              allow:
+                summary: Approve device
+                value:
+                  device_code: "crs1abc2def3ghi4"
+                  action: "allow"
+              deny:
+                summary: Deny device
+                value:
+                  device_code: "crs1abc2def3ghi4"
+                  action: "deny"
+      responses:
+        "200":
+          description: Device authorization action processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - approved
+                      - denied
+                    example: "approved"
+        "400":
+          description: Invalid request (bad action or request already processed)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                invalidAction:
+                  summary: Invalid action
+                  value:
+                    error: "invalid action, must be 'allow' or 'deny'"
+                alreadyProcessed:
+                  summary: Already processed
+                  value:
+                    error: "device auth request already processed"
+        "404":
+          description: Device authorization request not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/auth/device-token:
+    get:
+      tags:
+        - Device Authorization
+      summary: Poll for device authorization token
+      description: |
+        Polled by the CLI to check if the user has approved the device authorization request.
+        Returns the token when approved, or the current status if still pending or denied.
+        This endpoint does not require authentication.
+      operationId: deviceToken
+      security: []
+      parameters:
+        - name: code
+          in: query
+          required: true
+          description: The device code from the authorization request
+          schema:
+            type: string
+            example: "crs1abc2def3ghi4"
+      responses:
+        "200":
+          description: Device token status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceTokenResponse"
+              examples:
+                pending:
+                  summary: Still waiting for user approval
+                  value:
+                    status: "pending"
+                approved:
+                  summary: Approved - token returned
+                  value:
+                    status: "approved"
+                    token: "a1b2c3d4e5f6..."
+                denied:
+                  summary: User denied the request
+                  value:
+                    status: "denied"
+        "400":
+          description: Missing device code parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingCode:
+                  summary: Missing code
+                  value:
+                    error: "missing code parameter"
+        "404":
+          description: Device authorization request not found or expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                notFound:
+                  summary: Not found
+                  value:
+                    error: "device auth request not found"
+
+  /api/tokens:
+    get:
+      tags:
+        - API Tokens
+      summary: List all API tokens
+      description: Returns a list of all API tokens (connected clients) with their metadata. Token hashes are never returned.
+      operationId: listTokens
+      responses:
+        "200":
+          description: List of API tokens
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAPITokensResponse"
+              examples:
+                success:
+                  summary: Tokens list
+                  value:
+                    tokens:
+                      - id: "crs1abc2def3ghi4"
+                        name: "CLI Device crs1abc2"
+                        created_at: 1672531200
+                        last_used: 1672617600
+                        revoked: false
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/tokens/{id}/revoke:
+    post:
+      tags:
+        - API Tokens
+      summary: Revoke an API token
+      description: Revokes an API token, preventing it from being used for future authentication. This action cannot be undone.
+      operationId: revokeToken
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique identifier of the API token to revoke
+          schema:
+            type: string
+            example: "crs1abc2def3ghi4"
+      responses:
+        "200":
+          description: Token revoked successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "revoked"
+        "404":
+          description: Token not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                notFound:
+                  summary: Token not found
+                  value:
+                    error: "token not found"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /fn/{function_id}:
     parameters:
       - name: function_id
@@ -2037,3 +2349,142 @@ components:
           type: integer
           description: Number of items skipped
           example: 0
+
+    DeviceRequestResponse:
+      type: object
+      required:
+        - device_code
+        - user_code
+        - approval_url
+        - expires_in
+        - interval
+      properties:
+        device_code:
+          type: string
+          description: Unique device code used to identify this authorization request
+          example: "crs1abc2def3ghi4"
+        user_code:
+          type: string
+          description: Short alphanumeric code displayed to the user for verification
+          example: "ABCD-EFGH"
+        approval_url:
+          type: string
+          description: URL where the user should approve the device authorization
+          example: "http://localhost:3000/#!/device-approve/crs1abc2def3ghi4"
+        expires_in:
+          type: integer
+          description: Number of seconds until this authorization request expires
+          example: 300
+        interval:
+          type: integer
+          description: Recommended polling interval in seconds for the device-token endpoint
+          example: 5
+
+    DeviceApproveRequest:
+      type: object
+      required:
+        - device_code
+        - action
+      properties:
+        device_code:
+          type: string
+          description: The device code from the authorization request
+          example: "crs1abc2def3ghi4"
+        action:
+          type: string
+          description: The action to take on the authorization request
+          enum:
+            - allow
+            - deny
+          example: "allow"
+
+    DeviceApproveStatusResponse:
+      type: object
+      required:
+        - device_code
+        - user_code
+        - status
+        - expires_at
+      properties:
+        device_code:
+          type: string
+          description: The device code for this authorization request
+          example: "crs1abc2def3ghi4"
+        user_code:
+          type: string
+          description: The user verification code
+          example: "ABCD-EFGH"
+        status:
+          type: string
+          description: Current status of the authorization request
+          enum:
+            - pending
+            - approved
+            - denied
+          example: "pending"
+        expires_at:
+          type: integer
+          format: int64
+          description: Unix timestamp when this authorization request expires
+          example: 1672531500
+
+    DeviceTokenResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Current status of the authorization request
+          enum:
+            - pending
+            - approved
+            - denied
+          example: "pending"
+        token:
+          type: string
+          description: The API token (only present when status is "approved"). This is the only time the raw token is returned.
+          example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+    APIToken:
+      type: object
+      required:
+        - id
+        - name
+        - created_at
+        - revoked
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the API token
+          example: "crs1abc2def3ghi4"
+        name:
+          type: string
+          description: Human-readable name for the token
+          example: "CLI Device crs1abc2"
+        created_at:
+          type: integer
+          format: int64
+          description: Unix timestamp when the token was created
+          example: 1672531200
+        last_used:
+          type: integer
+          format: int64
+          nullable: true
+          description: Unix timestamp when the token was last used (null if never used)
+          example: 1672617600
+        revoked:
+          type: boolean
+          description: Whether the token has been revoked
+          example: false
+
+    ListAPITokensResponse:
+      type: object
+      required:
+        - tokens
+      properties:
+        tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/APIToken"
+          description: List of API tokens

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,6 +32,8 @@ type Server struct {
 	apiKey          string
 	httpServer      *http.Server
 	kvStore         kv.Store
+	deviceAuth      *DeviceAuthStore
+	baseURL         string
 }
 
 // ServerConfig holds configuration for creating a Server
@@ -102,6 +104,8 @@ func NewServer(config ServerConfig) *Server {
 		frontendHandler: config.FrontendHandler,
 		apiKey:          config.APIKey,
 		kvStore:         config.KVStore,
+		deviceAuth:      NewDeviceAuthStore(),
+		baseURL:         config.BaseURL,
 	}
 
 	s.setupRoutes()
@@ -114,6 +118,10 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("POST /api/auth/login", HandleLogin(s.apiKey))
 	s.mux.HandleFunc("POST /api/auth/logout", HandleLogout())
 
+	// Device auth flow (no auth required for request and poll)
+	s.mux.HandleFunc("POST /api/auth/device-request", HandleDeviceRequest(s.deviceAuth, s.baseURL))
+	s.mux.HandleFunc("GET /api/auth/device-token", HandleDeviceToken(s.deviceAuth))
+
 	// API documentation (no authentication required)
 	s.mux.HandleFunc("GET /docs", docsPageHandler)
 	s.mux.HandleFunc("HEAD /docs", docsPageHandler)
@@ -121,7 +129,7 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("HEAD /docs/openapi.yaml", openAPISpecHandler)
 
 	// Protected API routes - wrap with auth middleware
-	authMiddleware := AuthMiddleware(s.apiKey)
+	authMiddleware := AuthMiddleware(s.apiKey, s.db)
 
 	// Function Management - only need DB
 	s.mux.Handle("POST /api/functions", authMiddleware(http.HandlerFunc(CreateFunctionHandler(s.db))))
@@ -146,6 +154,14 @@ func (s *Server) setupRoutes() {
 	s.mux.Handle("GET /api/executions/{id}/logs", authMiddleware(http.HandlerFunc(GetExecutionLogsHandler(s.db, s.logger))))
 	s.mux.Handle("GET /api/executions/{id}/ai-requests", authMiddleware(http.HandlerFunc(GetExecutionAIRequestsHandler(s.db, s.aiTracker))))
 	s.mux.Handle("GET /api/executions/{id}/email-requests", authMiddleware(http.HandlerFunc(GetExecutionEmailRequestsHandler(s.db, s.emailTracker))))
+
+	// Device approval (auth required - user must be logged in)
+	s.mux.Handle("GET /api/auth/device-approve", authMiddleware(http.HandlerFunc(HandleDeviceApproveStatus(s.deviceAuth))))
+	s.mux.Handle("POST /api/auth/device-approve", authMiddleware(http.HandlerFunc(HandleDeviceApprove(s.deviceAuth, s.db))))
+
+	// API token management (auth required)
+	s.mux.Handle("GET /api/tokens", authMiddleware(http.HandlerFunc(HandleListAPITokens(s.db))))
+	s.mux.Handle("POST /api/tokens/{id}/revoke", authMiddleware(http.HandlerFunc(HandleRevokeAPIToken(s.db))))
 
 	// Runtime Execution - needs all dependencies (NO AUTH - public endpoint)
 	// Register both exact match and wildcard patterns for routing support

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -138,6 +138,35 @@ type PaginatedEmailRequestsResponse struct {
 	Pagination    store.PaginationInfo `json:"pagination"`
 }
 
+// DeviceRequestResponse is the response for POST /api/auth/device-request
+type DeviceRequestResponse struct {
+	DeviceCode  string `json:"device_code"`
+	UserCode    string `json:"user_code"`
+	ApprovalURL string `json:"approval_url"`
+	ExpiresIn   int    `json:"expires_in"`
+	Interval    int    `json:"interval"`
+}
+
+// DeviceApproveRequest is the request body for POST /api/auth/device-approve
+type DeviceApproveRequest struct {
+	DeviceCode string `json:"device_code"`
+	Action     string `json:"action"`
+}
+
+// DeviceApproveStatusResponse is the response for GET /api/auth/device-approve
+type DeviceApproveStatusResponse struct {
+	DeviceCode string `json:"device_code"`
+	UserCode   string `json:"user_code"`
+	Status     string `json:"status"`
+	ExpiresAt  int64  `json:"expires_at"`
+}
+
+// DeviceTokenResponse is the response for GET /api/auth/device-token
+type DeviceTokenResponse struct {
+	Status string `json:"status"`
+	Token  string `json:"token,omitempty"`
+}
+
 // NextRunResponse is the response for getting the next scheduled run time
 type NextRunResponse struct {
 	HasSchedule  bool    `json:"has_schedule"`

--- a/internal/migrate/migrations/000010_add_api_tokens.down.sql
+++ b/internal/migrate/migrations/000010_add_api_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_tokens;

--- a/internal/migrate/migrations/000010_add_api_tokens.up.sql
+++ b/internal/migrate/migrations/000010_add_api_tokens.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id TEXT PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_used INTEGER,
+    revoked INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_tokens_token_hash ON api_tokens(token_hash);

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -15,6 +15,7 @@ type MemoryDB struct {
 	functions  map[string]Function
 	versions   map[string][]FunctionVersion // functionID -> versions
 	executions map[string]Execution         // id -> execution
+	apiTokens  map[string]APIToken          // id -> token
 }
 
 // NewMemoryDB creates a new in-memory database
@@ -23,6 +24,7 @@ func NewMemoryDB() *MemoryDB {
 		functions:  make(map[string]Function),
 		versions:   make(map[string][]FunctionVersion),
 		executions: make(map[string]Execution),
+		apiTokens:  make(map[string]APIToken),
 	}
 }
 
@@ -422,6 +424,70 @@ func (db *MemoryDB) ListFunctionsWithActiveCron(_ context.Context) ([]Function, 
 	}
 
 	return functions, nil
+}
+
+// API Token operations
+
+func (db *MemoryDB) CreateAPIToken(_ context.Context, token APIToken) (APIToken, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	token.CreatedAt = time.Now().Unix()
+	db.apiTokens[token.ID] = token
+	return token, nil
+}
+
+func (db *MemoryDB) GetAPITokenByHash(_ context.Context, tokenHash string) (APIToken, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	for _, token := range db.apiTokens {
+		if token.TokenHash == tokenHash && !token.Revoked {
+			return token, nil
+		}
+	}
+
+	return APIToken{}, ErrAPITokenNotFound
+}
+
+func (db *MemoryDB) ListAPITokens(_ context.Context) ([]APIToken, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	tokens := make([]APIToken, 0, len(db.apiTokens))
+	for _, token := range db.apiTokens {
+		tokens = append(tokens, token)
+	}
+
+	return tokens, nil
+}
+
+func (db *MemoryDB) RevokeAPIToken(_ context.Context, id string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	token, ok := db.apiTokens[id]
+	if !ok {
+		return ErrAPITokenNotFound
+	}
+
+	token.Revoked = true
+	db.apiTokens[id] = token
+	return nil
+}
+
+func (db *MemoryDB) UpdateAPITokenLastUsed(_ context.Context, id string, timestamp int64) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	token, ok := db.apiTokens[id]
+	if !ok {
+		return ErrAPITokenNotFound
+	}
+
+	token.LastUsed = &timestamp
+	db.apiTokens[id] = token
+	return nil
 }
 
 // Health check

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -711,6 +711,101 @@ func (db *SQLiteDB) DeleteOldExecutions(ctx context.Context, beforeTimestamp int
 	return rowsAffected, nil
 }
 
+// API Token operations
+
+func (db *SQLiteDB) CreateAPIToken(ctx context.Context, token APIToken) (APIToken, error) {
+	token.CreatedAt = time.Now().Unix()
+
+	query := `INSERT INTO api_tokens (id, token_hash, name, created_at, revoked)
+	          VALUES (?, ?, ?, ?, 0)`
+
+	_, err := db.db.ExecContext(ctx, query, token.ID, token.TokenHash, token.Name, token.CreatedAt)
+	if err != nil {
+		return APIToken{}, fmt.Errorf("failed to insert api token: %w", err)
+	}
+
+	return token, nil
+}
+
+func (db *SQLiteDB) GetAPITokenByHash(ctx context.Context, tokenHash string) (APIToken, error) {
+	query := `SELECT id, token_hash, name, created_at, last_used, revoked
+	          FROM api_tokens WHERE token_hash = ? AND revoked = 0`
+
+	var token APIToken
+	var lastUsed sql.NullInt64
+
+	err := db.db.QueryRowContext(ctx, query, tokenHash).Scan(
+		&token.ID, &token.TokenHash, &token.Name, &token.CreatedAt, &lastUsed, &token.Revoked,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return APIToken{}, ErrAPITokenNotFound
+	}
+	if err != nil {
+		return APIToken{}, fmt.Errorf("failed to query api token: %w", err)
+	}
+
+	if lastUsed.Valid {
+		token.LastUsed = &lastUsed.Int64
+	}
+
+	return token, nil
+}
+
+func (db *SQLiteDB) ListAPITokens(ctx context.Context) ([]APIToken, error) {
+	query := `SELECT id, token_hash, name, created_at, last_used, revoked
+	          FROM api_tokens ORDER BY created_at DESC`
+
+	rows, err := db.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query api tokens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []APIToken
+	for rows.Next() {
+		var token APIToken
+		var lastUsed sql.NullInt64
+
+		if err := rows.Scan(&token.ID, &token.TokenHash, &token.Name, &token.CreatedAt, &lastUsed, &token.Revoked); err != nil {
+			return nil, fmt.Errorf("failed to scan api token: %w", err)
+		}
+
+		if lastUsed.Valid {
+			token.LastUsed = &lastUsed.Int64
+		}
+
+		tokens = append(tokens, token)
+	}
+
+	return tokens, rows.Err()
+}
+
+func (db *SQLiteDB) RevokeAPIToken(ctx context.Context, id string) error {
+	result, err := db.db.ExecContext(ctx, "UPDATE api_tokens SET revoked = 1 WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("failed to revoke api token: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rows == 0 {
+		return ErrAPITokenNotFound
+	}
+
+	return nil
+}
+
+func (db *SQLiteDB) UpdateAPITokenLastUsed(ctx context.Context, id string, timestamp int64) error {
+	_, err := db.db.ExecContext(ctx, "UPDATE api_tokens SET last_used = ? WHERE id = ?", timestamp, id)
+	if err != nil {
+		return fmt.Errorf("failed to update api token last_used: %w", err)
+	}
+	return nil
+}
+
 // Health check
 
 func (db *SQLiteDB) Ping(ctx context.Context) error {

--- a/internal/store/sqlite_api_tokens_test.go
+++ b/internal/store/sqlite_api_tokens_test.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSQLiteDB_CreateAPIToken(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	token := APIToken{
+		ID:        "token_123",
+		TokenHash: "abc123hash",
+		Name:      "CLI (ABCD1234)",
+	}
+
+	created, err := sqliteDB.CreateAPIToken(ctx, token)
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	if created.ID != token.ID {
+		t.Errorf("expected ID %s, got %s", token.ID, created.ID)
+	}
+	if created.Name != token.Name {
+		t.Errorf("expected Name %s, got %s", token.Name, created.Name)
+	}
+	if created.TokenHash != token.TokenHash {
+		t.Errorf("expected TokenHash %s, got %s", token.TokenHash, created.TokenHash)
+	}
+	if created.CreatedAt == 0 {
+		t.Error("expected CreatedAt to be set")
+	}
+	if created.Revoked {
+		t.Error("expected Revoked to be false")
+	}
+	if created.LastUsed != nil {
+		t.Error("expected LastUsed to be nil")
+	}
+}
+
+func TestSQLiteDB_GetAPITokenByHash(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	token := APIToken{
+		ID:        "token_456",
+		TokenHash: "hash456",
+		Name:      "CLI (EFGH5678)",
+	}
+
+	_, err := sqliteDB.CreateAPIToken(ctx, token)
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	// Retrieve by hash
+	found, err := sqliteDB.GetAPITokenByHash(ctx, "hash456")
+	if err != nil {
+		t.Fatalf("GetAPITokenByHash failed: %v", err)
+	}
+
+	if found.ID != token.ID {
+		t.Errorf("expected ID %s, got %s", token.ID, found.ID)
+	}
+	if found.Name != token.Name {
+		t.Errorf("expected Name %s, got %s", token.Name, found.Name)
+	}
+}
+
+func TestSQLiteDB_GetAPITokenByHash_NotFound(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	_, err := sqliteDB.GetAPITokenByHash(ctx, "nonexistent")
+	if err != ErrAPITokenNotFound {
+		t.Errorf("expected ErrAPITokenNotFound, got %v", err)
+	}
+}
+
+func TestSQLiteDB_GetAPITokenByHash_Revoked(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	token := APIToken{
+		ID:        "token_revoked",
+		TokenHash: "revoked_hash",
+		Name:      "CLI (REVOKED)",
+	}
+
+	_, err := sqliteDB.CreateAPIToken(ctx, token)
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	// Revoke the token
+	err = sqliteDB.RevokeAPIToken(ctx, token.ID)
+	if err != nil {
+		t.Fatalf("RevokeAPIToken failed: %v", err)
+	}
+
+	// Should not find revoked token
+	_, err = sqliteDB.GetAPITokenByHash(ctx, "revoked_hash")
+	if err != ErrAPITokenNotFound {
+		t.Errorf("expected ErrAPITokenNotFound for revoked token, got %v", err)
+	}
+}
+
+func TestSQLiteDB_ListAPITokens(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	// Empty list
+	tokens, err := sqliteDB.ListAPITokens(ctx)
+	if err != nil {
+		t.Fatalf("ListAPITokens failed: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Errorf("expected empty list, got %d tokens", len(tokens))
+	}
+
+	// Create two tokens
+	_, err = sqliteDB.CreateAPIToken(ctx, APIToken{
+		ID:        "token_1",
+		TokenHash: "hash_1",
+		Name:      "CLI 1",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	_, err = sqliteDB.CreateAPIToken(ctx, APIToken{
+		ID:        "token_2",
+		TokenHash: "hash_2",
+		Name:      "CLI 2",
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	tokens, err = sqliteDB.ListAPITokens(ctx)
+	if err != nil {
+		t.Fatalf("ListAPITokens failed: %v", err)
+	}
+	if len(tokens) != 2 {
+		t.Errorf("expected 2 tokens, got %d", len(tokens))
+	}
+}
+
+func TestSQLiteDB_RevokeAPIToken(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	token := APIToken{
+		ID:        "token_to_revoke",
+		TokenHash: "hash_to_revoke",
+		Name:      "CLI (REVOKE ME)",
+	}
+
+	_, err := sqliteDB.CreateAPIToken(ctx, token)
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	err = sqliteDB.RevokeAPIToken(ctx, token.ID)
+	if err != nil {
+		t.Fatalf("RevokeAPIToken failed: %v", err)
+	}
+
+	// Verify it shows as revoked in listing
+	tokens, err := sqliteDB.ListAPITokens(ctx)
+	if err != nil {
+		t.Fatalf("ListAPITokens failed: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d", len(tokens))
+	}
+	if !tokens[0].Revoked {
+		t.Error("expected token to be revoked")
+	}
+}
+
+func TestSQLiteDB_RevokeAPIToken_NotFound(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	err := sqliteDB.RevokeAPIToken(ctx, "nonexistent")
+	if err != ErrAPITokenNotFound {
+		t.Errorf("expected ErrAPITokenNotFound, got %v", err)
+	}
+}
+
+func TestSQLiteDB_UpdateAPITokenLastUsed(t *testing.T) {
+	db, sqliteDB := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	token := APIToken{
+		ID:        "token_last_used",
+		TokenHash: "hash_last_used",
+		Name:      "CLI (LAST USED)",
+	}
+
+	_, err := sqliteDB.CreateAPIToken(ctx, token)
+	if err != nil {
+		t.Fatalf("CreateAPIToken failed: %v", err)
+	}
+
+	var timestamp int64 = 1700000000
+	err = sqliteDB.UpdateAPITokenLastUsed(ctx, token.ID, timestamp)
+	if err != nil {
+		t.Fatalf("UpdateAPITokenLastUsed failed: %v", err)
+	}
+
+	// Verify via GetAPITokenByHash
+	found, err := sqliteDB.GetAPITokenByHash(ctx, "hash_last_used")
+	if err != nil {
+		t.Fatalf("GetAPITokenByHash failed: %v", err)
+	}
+	if found.LastUsed == nil {
+		t.Fatal("expected LastUsed to be set")
+	}
+	if *found.LastUsed != timestamp {
+		t.Errorf("expected LastUsed %d, got %d", timestamp, *found.LastUsed)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,6 +14,7 @@ var (
 	ErrNoActiveVersion           = errors.New("no active version")
 	ErrExecutionNotFound         = errors.New("execution not found")
 	ErrCannotDeleteActiveVersion = errors.New("cannot delete active version")
+	ErrAPITokenNotFound          = errors.New("api token not found")
 )
 
 // DB defines the database interface for the Lunar API.
@@ -89,4 +90,21 @@ type DB interface {
 
 	// Ping verifies the database connection is alive.
 	Ping(ctx context.Context) error
+
+	// CreateAPIToken stores a new API token.
+	CreateAPIToken(ctx context.Context, token APIToken) (APIToken, error)
+
+	// GetAPITokenByHash retrieves a non-revoked API token by its hash.
+	// Returns ErrAPITokenNotFound if no matching token exists.
+	GetAPITokenByHash(ctx context.Context, tokenHash string) (APIToken, error)
+
+	// ListAPITokens returns all API tokens ordered by creation date.
+	ListAPITokens(ctx context.Context) ([]APIToken, error)
+
+	// RevokeAPIToken marks an API token as revoked.
+	// Returns ErrAPITokenNotFound if the token does not exist.
+	RevokeAPIToken(ctx context.Context, id string) error
+
+	// UpdateAPITokenLastUsed updates the last_used timestamp for a token.
+	UpdateAPITokenLastUsed(ctx context.Context, id string, timestamp int64) error
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -161,6 +161,16 @@ type PaginationInfo struct {
 	Offset int   `json:"offset"` // Items skipped
 }
 
+// APIToken represents a stored API token for CLI authentication
+type APIToken struct {
+	ID        string `json:"id"`
+	TokenHash string `json:"-"`
+	Name      string `json:"name"`
+	CreatedAt int64  `json:"created_at"`
+	LastUsed  *int64 `json:"last_used,omitempty"`
+	Revoked   bool   `json:"revoked"`
+}
+
 // UpdateFunctionRequest is the request body for updating a function
 type UpdateFunctionRequest struct {
 	Name          *string `json:"name,omitempty"`

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,24 @@
+// Package token provides secure token generation and hashing utilities.
+package token
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// Generate creates a cryptographically secure random token.
+// Returns a 64-character hex string (32 random bytes).
+func Generate() (string, error) {
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(randomBytes), nil
+}
+
+// Hash returns the hex-encoded SHA-256 hash of a token string.
+func Hash(t string) string {
+	h := sha256.Sum256([]byte(t))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -1,0 +1,43 @@
+package token
+
+import (
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	tok, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate() returned error: %v", err)
+	}
+
+	if len(tok) != 64 {
+		t.Errorf("expected 64-char hex string, got %d chars", len(tok))
+	}
+
+	// Should produce unique tokens
+	tok2, err := Generate()
+	if err != nil {
+		t.Fatalf("Generate() returned error: %v", err)
+	}
+	if tok == tok2 {
+		t.Error("Generate() produced identical tokens")
+	}
+}
+
+func TestHash(t *testing.T) {
+	hash := Hash("test-token")
+
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars", len(hash))
+	}
+
+	// Same input should produce same hash
+	if hash != Hash("test-token") {
+		t.Error("Hash() is not deterministic")
+	}
+
+	// Different input should produce different hash
+	if hash == Hash("other-token") {
+		t.Error("Hash() produced same hash for different inputs")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement OAuth 2.0-style device authorization flow enabling external tools to authenticate with Lunar
- Add API token management (create via device approval, list, revoke) with secure hash-only storage
- Add frontend views for device approval and connected clients management
- Extend auth middleware to accept Bearer tokens alongside the admin API key

This is the foundation work to enable a CLI client that will come later.

## What's included

**Server-side:**
- `api_tokens` table (migration 000010) storing only SHA-256 hashes of tokens
- In-memory `DeviceAuthStore` for short-lived pending auth requests (5 min TTL)
- Four device auth endpoints: `POST /api/auth/device-request`, `GET/POST /api/auth/device-approve`, `GET /api/auth/device-token`
- Token management endpoints: `GET /api/tokens`, `POST /api/tokens/{id}/revoke`
- `AuthMiddleware` extended to validate Bearer tokens via hashed lookup
- `internal/token` package for secure token generation and hashing

**Frontend:**
- Device approval view (`#!/device-approve/:code`) with new `CodeDisplay` component
- Connected clients view (`#!/clients`) matching existing table layout patterns
- Functions and Clients links added to navbar and command palette
- OpenAPI docs updated with all new endpoints and schemas
- Full i18n support (en + pt-BR)

**Screenshots:**
<img width="1464" height="482" alt="Screenshot 2026-03-15 at 21 39 04" src="https://github.com/user-attachments/assets/05fb3aee-a9d3-4df0-864c-c96e9efdbf3d" />

<img width="1464" height="379" alt="Screenshot 2026-03-15 at 21 32 53" src="https://github.com/user-attachments/assets/39f5118d-c188-4340-895d-d6cb91d5264a" />

